### PR TITLE
Add exported function for retrieving the UNIX timestamp

### DIFF
--- a/internal/imported.go
+++ b/internal/imported.go
@@ -12,7 +12,7 @@ import (
 
 // ImportedFunctions returns all functions 1Password SDK core must import.
 func ImportedFunctions() []extism.HostFunction {
-	return []extism.HostFunction{randomFillImportedFunc(), getTimeFunc()}
+	return []extism.HostFunction{randomFillImportedFunc(), currentTimeImportedFunc()}
 }
 
 // randomFillImportedFunc returns an Extism Function for generating random byte sequence of a given length that will be imported into the WASM core.
@@ -28,7 +28,7 @@ func randomFillImportedFunc() extism.HostFunction {
 }
 
 // getTimeFunc returns an Extism Function for retrieving the current UNIX time.
-func getTimeFunc() extism.HostFunction {
+func currentTimeImportedFunc() extism.HostFunction {
 	getTimeFunc := extism.NewHostFunctionWithStack("unix_time_milliseconds_imported", func(ctx context.Context, p *extism.CurrentPlugin, stack []uint64) {
 		stack[0] = uint64(time.Now().UnixMilli())
 	}, []api.ValueType{}, []api.ValueType{api.ValueTypeI64})


### PR DESCRIPTION
The SDK core needs to enforce that user sessions have a life of 30 minutes.

Since WASM does not offer native functionality for a monotonous clock, the WASM host will be required to provide the timestamp for the session management.

This MR adds a function for retrieving the UNIX millisecond timestamp from the Go, in a `now` function imported in the SDK core.