### PR TITLE
Add more context for getting started to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export GOPRIVATE=${GOPRIVATE},github.com/1password/*
 go get github.com/1password/1password-go-sdk
 ```
 
-5. Use the SDK in your project: 
+5. Use the SDK in your project:
 
 ```go
 import (


### PR DESCRIPTION
This MR updates the ReadMe to add a little more context for getting started. It makes the following changes:
- Specifies the supported authentication method earlier on.
- Adds a "Get started" header above the instructions for getting started.
- Notes that the service account will need access to the vaults where the secrets the person wants to use with the project are stored, since this can be an easy requirement to miss. 
- Adds a step to export the service account token, since this isn't mentioned in the guide to creating a service account.
- Notes that they should use secret references in their code, and highlights the example secret reference in the code example, so that the user will know to replace that with a reference to their own secret and have a link to learn more about what secret references are.
- Adds a link to the GOPRIVATE environment variable documentation.
- Makes a couple minor style edits.