### PR TITLE
Update tests to use secrets in new test account

### DIFF
--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -29,10 +29,10 @@ func TestSecretRetrievalFromTestAccount(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	secret, err := client.Secrets.Resolve("op://tfctuk7dxnrwjwqqhwatuhy3gi/dqtyg7dswx5kvpcxwv32psdbse/password")
+	secret, err := client.Secrets.Resolve("op://gowwbvgow7kxocrfmfvtwni6vi/6ydrn7ne6mwnqc2prsbqx4i4aq/password")
 	require.NoError(t, err)
 
-	assert.Equal(t, "test_password", secret)
+	assert.Equal(t, "test_password_42", secret)
 }
 
 func TestRetrivalWithMultipleClients(t *testing.T) {
@@ -82,7 +82,7 @@ func TestInvalidInvoke(t *testing.T) {
 
 	validClientID := uint64(0)
 	validMethodName := "Resolve"
-	validParams := "op://tfctuk7dxnrwjwqqhwatuhy3gi/dqtyg7dswx5kvpcxwv32psdbse/password"
+	validParams := "op://gowwbvgow7kxocrfmfvtwni6vi/6ydrn7ne6mwnqc2prsbqx4i4aq/password"
 	invalidClientID := uint64(1)
 	invalidMethodName := "InvalidName"
 	invalidParams := ""
@@ -154,10 +154,10 @@ func TestConcurrentCallsFromOneClient(t *testing.T) {
 	wg.Add(concurrentCalls)
 	for i := 0; i < concurrentCalls; i++ {
 		go func() {
-			secret, err := client.Secrets.Resolve("op://tfctuk7dxnrwjwqqhwatuhy3gi/dqtyg7dswx5kvpcxwv32psdbse/password")
+			secret, err := client.Secrets.Resolve("op://gowwbvgow7kxocrfmfvtwni6vi/6ydrn7ne6mwnqc2prsbqx4i4aq/password")
 			require.NoError(t, err)
 
-			assert.Equal(t, "test_password", secret)
+			assert.Equal(t, "test_password_42", secret)
 			wg.Done()
 		}()
 	}
@@ -180,10 +180,10 @@ func TestConcurrentCallsFromMultipleClientsOnTheSameToken(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			secret, err := client.Secrets.Resolve("op://tfctuk7dxnrwjwqqhwatuhy3gi/dqtyg7dswx5kvpcxwv32psdbse/password")
+			secret, err := client.Secrets.Resolve("op://gowwbvgow7kxocrfmfvtwni6vi/6ydrn7ne6mwnqc2prsbqx4i4aq/password")
 			require.NoError(t, err)
 
-			assert.Equal(t, "test_password", secret)
+			assert.Equal(t, "test_password_42", secret)
 			wg.Done()
 		}()
 	}


### PR DESCRIPTION
To standardize CICD tests across all SDKs and reduce the chance of accidentally breaking them, I created a separate vault for the CI tests of all SDKs.

This MR updates the secret references and values used in the tests to reflect the ones actually present in the new test vault