### PR TITLE
Ask for version in bug reports, not in feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -24,6 +24,11 @@ body:
       label: Expected Behavior
       description: What would you have expected happened instead?
       placeholder: "Please share what you had expected to happen. How should this have behaved?"
+  - type: input
+    id: version
+    attributes:
+      label: SDK version
+      description: "You can find the version you're using in the go.mod file."
   - type: textarea
     id: info
     attributes:

--- a/.github/ISSUE_TEMPLATE/3-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/3-feature-request.yml
@@ -21,8 +21,3 @@ body:
     attributes:
       label: Additional information
       description: Any additional information that's relevant to add?
-  - type: input
-    id: version
-    attributes:
-      label: SDK version
-      description: "You can find the version you're using in the go.mod file."


### PR DESCRIPTION
I erroronously added a request for version in the feature request issue template (in https://github.com/1Password/onepassword-sdk-go/pull/39). This should be in the bug report issue template instead, so we can easily reproduce the bug and identify if it's already resolved in recent versions. For feature requests, this should not be necessary.