### PR TITLE
Update README for beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://developer.1password.com/docs/sdks/">Documentation</a> | <a href="https://github.com/1Password/onepassword-sdk-go/tree/main/example">Examples</a>
+  <a href="https://github.com/1Password/onepassword-sdk-go/tree/main/example">Examples</a>
 <br/>
 
 ---
@@ -28,46 +28,45 @@ Before you get started, [create a service account](https://developer.1password.c
 
 1Password SDKs don't yet support using secret references with query parameters, so you can't retrieve file attachments or SSH keys, or get more information about field metadata.
 
-When managing items with 1Password SDKs, you must use [unique identifiers (IDs)](https://developer.1password.com/docs/sdks/concepts#unique-identifiers-ids) in place of vault, item, and field names.
+When managing items with 1Password SDKs, you must use unique identifiers (IDs) in place of vault, item, and field names.
 
 ## 🚀 Get started
 
 To use the 1Password Go SDK in your project:
 
 1. Provision your [service account](#authentication) token. We recommend provisioning your token from the environment. For example, to export your token to the `OP_SERVICE_ACCOUNT_TOKEN` environment variable:
-    
-    **macOS or Linux**
-    
-    ```bash
-    export OP_SERVICE_ACCOUNT_TOKEN=<your-service-account-token>
-    ```
-    
-    **Windows**
-    
-    ```powershell
-    $Env:OP_SERVICE_ACCOUNT_TOKEN = "<your-service-account-token>"
-    ```
 
+   **macOS or Linux**
+
+   ```bash
+   export OP_SERVICE_ACCOUNT_TOKEN=<your-service-account-token>
+   ```
+
+   **Windows**
+
+   ```powershell
+   $Env:OP_SERVICE_ACCOUNT_TOKEN = "<your-service-account-token>"
+   ```
 
 2. Add the 1Password GitHub namespace to your [`GOPRIVATE` environment variable](https://pkg.go.dev/cmd/go#hdr-Configuration_for_downloading_non_public_code):
 
-    **Mac**
+   **Mac**
 
-    ```bash
-    export GOPRIVATE=${GOPRIVATE},github.com/1password/*
-    ```
+   ```bash
+   export GOPRIVATE=${GOPRIVATE},github.com/1password/*
+   ```
 
-    **Windows**
-    
-    ```powershell
-    $Env:GOPRIVATE=${GOPRIVATE},github.com/1password/*
-    ```
+   **Windows**
+
+   ```powershell
+   $Env:GOPRIVATE=${GOPRIVATE},github.com/1password/*
+   ```
 
 3. Install the 1Password Go SDK in your project:
 
-    ```bash
-    go get github.com/1password/onepassword-sdk-go
-    ```
+   ```bash
+   go get github.com/1password/onepassword-sdk-go
+   ```
 
 4. Use the Go SDK in your project:
 
@@ -81,7 +80,7 @@ import (
 
 func main() {
     token := os.Getenv("OP_SERVICE_ACCOUNT_TOKEN")
-	
+
     client, err := onepassword.NewClient(
                 context.TODO(),
                 onepassword.WithServiceAccountToken(token),
@@ -98,12 +97,6 @@ func main() {
 }
 ```
 
-Inside ```onepassword.WithIntegrationInfo(...)```, pass the name of your application and the version of your application as arguments.
+Inside `onepassword.WithIntegrationInfo(...)`, pass the name of your application and the version of your application as arguments.
 
 Make sure to use [secret reference URIs](https://developer.1password.com/docs/cli/secrets-reference-syntax/) with the syntax `op://vault/item/field` to securely load secrets from 1Password into your code.
-
-## 📖 Learn more
-
-- [Load secrets with 1Password SDKs](https://developer.1password.com/docs/sdks/load-secrets)
-- [Manage items with 1Password SDKs](https://developer.1password.com/docs/sdks/manage-items)
-- [1Password SDK concepts](https://developer.1password.com/docs/sdks/concepts)


### PR DESCRIPTION
This MR updates the README for the beta. It includes the following changes:

- Some improved styling, like a centered header and beta callout
- Links to documentation
- Edits to reflect edits made for beta docs, like changing "read access" to "access", updating the warning callout text, etc.
- Separates authentication & limitation info into their own sections
- Updates get started steps to reflect beta docs changes (for example, removed any steps that are no longer needed for the beta)
- Rephrases token provision section to reflect beta docs changes, explaining using the `OP_SERVICE_ACCOUNT_TOKEN` environment variable as an option
- Adds PowerShell examples

Question for reviewer: Does the "Use the SDK in your project" code example need to be updated?