### PR TITLE
Raise the interval between GitHub Actions dependency update notifications

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
-      day: sunday
-    ignore:
-      - dependency-name: "*"
-        update-types: [ "version-update:semver-patch" ]
+      interval: monthly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
     schedule:
       interval: weekly
       day: sunday
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch" ]


### PR DESCRIPTION
## Summary

This PR will delay the Dependabot from triggering an update whenever a patch version gets bumped on either  `kunalnagarco/action-cve` or any other dependency which is part of this repo's GitHub actions.

## Thought process
I followed this documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval