### PR TITLE
Prepare release candidate v0.1.0-beta.9

### DIFF
--- a/internal/core.go
+++ b/internal/core.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	SDKSemverVersion      = "0010001" // v0.1.0
+	SDKSemverVersion      = "0010008" // v0.1.0-beta.8
 	SDKLanguage           = "Go"
 	DefaultRequestLibrary = "net/http"
 )


### PR DESCRIPTION
This release fixes a bug which caused the SDKs to incorrectly return errors for all function calls following a failed operation.