### PR TITLE
Remove unnecessary data loss warning

### DIFF
--- a/items.go
+++ b/items.go
@@ -14,9 +14,9 @@ type ItemsAPI interface {
 	Create(ctx context.Context, item Item) (Item, error)
 	// Get an item by vault and item ID
 	Get(ctx context.Context, vaultId string, itemId string) (Item, error)
-	// Update an existing item. Warning: Only text and concealed fields are currently supported. Other fields will be permanently lost when you update an item.
+	// Update an existing item. You can currently only edit text and concealed fields.
 	Update(ctx context.Context, item Item) (Item, error)
-	// Delete an item. Warning:  Information saved in fields other than text and concealed fields will be permanently lost.
+	// Delete an item. 
 	Delete(ctx context.Context, vaultId string, itemId string) error
 }
 


### PR DESCRIPTION
This MR removes an unnecessary data loss warning from the item code comments.