### PR TITLE
Fix unnoticed release bugs

### DIFF
--- a/internal/release/scripts/prep-release.sh
+++ b/internal/release/scripts/prep-release.sh
@@ -64,8 +64,8 @@ update_and_validate_version
 # Update and validate the build number
 update_and_validate_build 
 
-if [[ "$current_build_number" -ge "$build" ]]; then
-    echo "Build version hasn't changed or is lower than current build version. Stopping." >&2
+if [[ "$current_build_number" == "$build" || "$current_build_number" > "$build" ]]; then
+    echo "Build version hasn't changed or is less than current build version. Stopping." >&2
     exit 1
 fi
 

--- a/internal/release/scripts/prep-release.sh
+++ b/internal/release/scripts/prep-release.sh
@@ -16,7 +16,8 @@ cleanup() {
     rm -f "${changelog_file}"
     # Revert changes to file if any
     echo "${current_version}" > "${version_file}"
-    echo "${current_build}" > "${build_file}"   
+    echo "${current_build}" > "${build_file}"
+    exit 1   
 }
 
 # Set the trap to call the cleanup function on exit
@@ -65,7 +66,7 @@ update_and_validate_build() {
                 return 0
             else
                 echo "Build version hasn't changed or is less than current build version. Stopping." >&2
-                exit 1
+                cleanup
             fi
         else
             echo "Invalid build number format: ${build}"

--- a/internal/release/scripts/prep-release.sh
+++ b/internal/release/scripts/prep-release.sh
@@ -64,7 +64,7 @@ update_and_validate_version
 # Update and validate the build number
 update_and_validate_build 
 
-if [[ "$current_build_number" == "$build" || "$current_build_number" > "$build" ]]; then
+if (( 10#$current_build_number >= 10#$build )); then
     echo "Build version hasn't changed or is less than current build version. Stopping." >&2
     exit 1
 fi

--- a/internal/release/scripts/prep-release.sh
+++ b/internal/release/scripts/prep-release.sh
@@ -80,16 +80,17 @@ branch="$(git rev-parse --abbrev-ref HEAD)"
 
 # if on main, then stash changes and create RC branch
 if [[ "${branch}" = "main" ]]; then
+    branch=rc/"${version}"
     git stash
     git fetch origin
-    git checkout -b rc/"${version}"
+    git checkout -b "${branch}"
     git stash apply
 fi
 
 # Add changes and commit/push to branch
 git add .
 git commit -S -m "Release v${version}"
-git push --set-upstream origin rc/"${version}"
+git push --set-upstream origin "${branch}"
 
 echo "Release has been prepared..
 Make sure to double check version/build numbers in their appropriate files and

--- a/internal/release/scripts/prep-release.sh
+++ b/internal/release/scripts/prep-release.sh
@@ -45,7 +45,7 @@ update_and_validate_version() {
                 echo "New version number is: ${version}"
                 return 0
             else
-                echo "Version hasn't changed or is less than current version."
+                echo "Version hasn't changed."
             fi        
         else
             echo "Invalid version number format: ${version}"
@@ -69,7 +69,7 @@ update_and_validate_build() {
                 echo "New build number is: ${build}"
                 return 0
             else
-                echo "Build version hasn't changed or is less than current build version."
+                echo "New build version should be higher than current build version."
             fi
         else
             echo "Invalid build number format: ${build}"

--- a/internal/release/scripts/prep-release.sh
+++ b/internal/release/scripts/prep-release.sh
@@ -20,7 +20,7 @@ cleanup() {
 }
 
 # Set the trap to call the cleanup function on exit
-trap cleanup EXIT
+trap cleanup EXIT ERR
 
 enforce_latest_code() {
     if [[ -n "$(git status --porcelain=v1)" ]]; then

--- a/internal/release/scripts/prep-release.sh
+++ b/internal/release/scripts/prep-release.sh
@@ -20,7 +20,7 @@ cleanup() {
 }
 
 # Set the trap to call the cleanup function on exit
-trap cleanup EXIT ERR
+trap cleanup ERR SIGINT
 
 enforce_latest_code() {
     if [[ -n "$(git status --porcelain=v1)" ]]; then

--- a/internal/release/scripts/prep-release.sh
+++ b/internal/release/scripts/prep-release.sh
@@ -2,11 +2,25 @@
 
 # Helper script to prepare a release for the Go SDK.
 
-# Read the current build number from version-build to make sure the build number has been updated
-current_build_number=$(< internal/release/version-build)
+# Read current build and version for backup as well as comparison to new build
+current_build=$(< internal/release/version-build)
+current_version=$(< internal/release/version)
 
 version_file="internal/release/version"
 build_file="internal/release/version-build"
+
+# Function to execute upon exit
+cleanup() {
+    echo "Performing cleanup tasks..."
+    # Remove changelog file if it exists
+    rm -f "${changelog_file}"
+    # Revert changes to file if any
+    echo "${current_version}" > "${version_file}"
+    echo "${current_build}" > "${build_file}"   
+}
+
+# Set the trap to call the cleanup function on exit
+trap cleanup EXIT
 
 enforce_latest_code() {
     if [[ -n "$(git status --porcelain=v1)" ]]; then
@@ -44,10 +58,15 @@ update_and_validate_build() {
 
         # Validate the build number format
         if [[ "${build}" =~ ^[0-9]{7}$ ]]; then
-            # Write the valid build number to the file
-            echo "${build}" > "${build_file}"
-            echo "New build number is: ${build}"
-            return 0
+            if (( 10#$current_build < 10#$build )); then
+                # Write the valid build number to the file
+                echo "${build}" > "${build_file}"
+                echo "New build number is: ${build}"
+                return 0
+            else
+                echo "Build version hasn't changed or is less than current build version. Stopping." >&2
+                exit 1
+            fi
         else
             echo "Invalid build number format: ${build}"
             echo "Please enter a build number in the 'Mmmppbb' format."
@@ -63,11 +82,6 @@ update_and_validate_version
 
 # Update and validate the build number
 update_and_validate_build 
-
-if (( 10#$current_build_number >= 10#$build )); then
-    echo "Build version hasn't changed or is less than current build version. Stopping." >&2
-    exit 1
-fi
 
 changelog_file="internal/release/changelogs/"${version}"-"${build}""
 

--- a/internal/release/scripts/prep-release.sh
+++ b/internal/release/scripts/prep-release.sh
@@ -21,7 +21,7 @@ cleanup() {
 }
 
 # Set the trap to call the cleanup function on exit
-trap cleanup ERR SIGINT
+trap cleanup SIGINT
 
 enforce_latest_code() {
     if [[ -n "$(git status --porcelain=v1)" ]]; then
@@ -36,13 +36,17 @@ update_and_validate_version() {
     while true; do
         # Prompt the user to input the version number
         read -p "Enter the version number (format: x.y.z(-beta.w)): " version
-
         # Validate the version number format
-        if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$ ]]; then        
-            # Write the valid version number to the file
-            echo "${version}" > "${version_file}"
-            echo "New version number is: ${version}"
-            return 0
+        if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$ ]]; then
+            # TODO: Check the less than case as well.
+            if [[ "${current_version}" != "${version}" ]]; then        
+                # Write the valid version number to the file
+                echo "${version}" > "${version_file}"
+                echo "New version number is: ${version}"
+                return 0
+            else
+                echo "Version hasn't changed or is less than current version."
+            fi        
         else
             echo "Invalid version number format: ${version}"
             echo "Please enter a version number in the 'x.y.z(-beta.w)' format."
@@ -65,8 +69,7 @@ update_and_validate_build() {
                 echo "New build number is: ${build}"
                 return 0
             else
-                echo "Build version hasn't changed or is less than current build version. Stopping." >&2
-                cleanup
+                echo "Build version hasn't changed or is less than current build version."
             fi
         else
             echo "Invalid build number format: ${build}"


### PR DESCRIPTION
On the release process, if its on a feature branch, it will not push the branch as its expecting the new branch name in format of "rc/..." but the feature branch could be anything.

Also the comparison between current build number and new build number would be incorrect at certain numbers as bash treats leading 0's as an octal number. This fixes it so it converts to base 10 and compares.

This MR will fix these bugs.