### PR TITLE
Change changelog structure

### DIFF
--- a/internal/release/README.md
+++ b/internal/release/README.md
@@ -11,7 +11,7 @@ make prep-release
 ```
 Follow the scripts instructions and the release has now been prepped.
 
-Step 3. Ensure that the correct files have been updated - i.e. version/build files, changelog has been updated. Suggest doing a `git diff` to see the changes.
+Step 3. Ensure that the correct files have been updated - i.e. version/build files, release-notes have been updated. Suggest doing a `git diff` to see the changes.
 
 Step 4. Ensure your GITHUB_TOKEN environment variable is set as this will allow you to create the tags/release and push it.
 

--- a/internal/release/README.md
+++ b/internal/release/README.md
@@ -11,7 +11,7 @@ make prep-release
 ```
 Follow the scripts instructions and the release has now been prepped.
 
-Step 3. Ensure that the correct files have been updated - i.e. version/build files, changelog has been added to this folder and has the correct file name and content. Suggest doing a `git diff` to see the changes.
+Step 3. Ensure that the correct files have been updated - i.e. version/build files, changelog has been updated. Suggest doing a `git diff` to see the changes.
 
 Step 4. Ensure your GITHUB_TOKEN environment variable is set as this will allow you to create the tags/release and push it.
 

--- a/internal/release/changelogs/0.1.0-beta.10-0010010
+++ b/internal/release/changelogs/0.1.0-beta.10-0010010
@@ -1,1 +1,0 @@
-This release removes some misguiding code comments.

--- a/internal/release/scripts/prep-release.sh
+++ b/internal/release/scripts/prep-release.sh
@@ -12,8 +12,6 @@ build_file="internal/release/version-build"
 # Function to execute upon exit
 cleanup() {
     echo "Performing cleanup tasks..."
-    # Remove changelog file if it exists
-    rm -f "${changelog_file}"
     # Revert changes to file if any
     echo "${current_version}" > "${version_file}"
     echo "${current_build}" > "${build_file}"
@@ -87,11 +85,9 @@ update_and_validate_version
 # Update and validate the build number
 update_and_validate_build 
 
-changelog_file="internal/release/changelogs/"${version}"-"${build}""
-
-printf "Press ENTER to edit the CHANGELOG in your default editor...\n"
+printf "Press ENTER to edit the RELEASE-NOTES in your default editor...\n"
 read -r _ignore
-${EDITOR:-nano} "$changelog_file"
+${EDITOR:-nano} "internal/release/RELEASE-NOTES"
 
 # Get Current Branch Name
 branch="$(git rev-parse --abbrev-ref HEAD)"

--- a/internal/release/scripts/release.sh
+++ b/internal/release/scripts/release.sh
@@ -7,7 +7,7 @@ set -e
 # Read the contents of the files into variables
 version=$(< internal/release/version)
 build=$(< internal/release/version-build)
-release-notes=$(< internal/release/RELEASE-NOTES)
+release_notes=$(< internal/release/RELEASE-NOTES)
 
 # Check if Github CLI is installed
 if ! command -v gh &> /dev/null; then
@@ -26,5 +26,5 @@ git tag -a -s  "v${version}" -m "${version}"
 # Push the tag to the branch
 git push origin tag "v${version}"
 
-gh release create "v${version}" --title "Release ${version}" --notes "${release-notes}" --repo github.com/1Password/onepassword-sdk-go
+gh release create "v${version}" --title "Release ${version}" --notes "${release_notes}" --repo github.com/1Password/onepassword-sdk-go
 

--- a/internal/release/scripts/release.sh
+++ b/internal/release/scripts/release.sh
@@ -5,9 +5,9 @@
 set -e
 
 # Read the contents of the files into variables
-version=$(<internal/release/version)
-build=$(<internal/release/version-build)
-changelog=$(<internal/release/changelogs/"${version}"-"${build}")
+version=$(< internal/release/version)
+build=$(< internal/release/version-build)
+release-notes=$(< internal/release/RELEASE-NOTES)
 
 # Check if Github CLI is installed
 if ! command -v gh &> /dev/null; then
@@ -26,5 +26,5 @@ git tag -a -s  "v${version}" -m "${version}"
 # Push the tag to the branch
 git push origin tag "v${version}"
 
-gh release create "v${version}" --title "Release ${version}" --notes "${changelog}" --repo github.com/1Password/onepassword-sdk-go
+gh release create "v${version}" --title "Release ${version}" --notes "${release-notes}" --repo github.com/1Password/onepassword-sdk-go
 


### PR DESCRIPTION
This MR is to change the way we store changelogs as per Andi's comment in the Python [MR](https://github.com/1Password/onepassword-sdk-python/pull/52)

This will change the following:
- Remove changelog folder and add a file in `internal/relelease/RELEASE-NOTES`.
- Store only the latest release notes in there
- Scripts updated accordingly

To Test:
Run the make targets and should work as usual.