### PR TITLE
Fix how we describe limitations on file attachments, SSH keys & query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The 1Password Go SDK offers programmatic access to your secrets in 1Password wit
 
 ## ❗ Limitations
 
-1Password SDKs don't yet support using secret references with query parameters, so you can't retrieve file attachments or SSH keys, or get more information about field metadata.
+1Password SDKs don't yet support using secret references to retrieve file attachments or SSH keys, or using query parameters with secret references to get more information about field and file attributes.
 
 1Password SDKs currently only support operations on text and concealed fields. As a result, you can't edit items that include information saved in other types of fields.
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ The 1Password Go SDK offers programmatic access to your secrets in 1Password wit
 
 ## ❗ Limitations
 
-1Password SDKs don't yet support using secret references to retrieve file attachments or SSH keys, or using query parameters with secret references to get more information about field and file attributes.
+With 1Password SDKs, you can retrieve the values of text and concealed fields from your items. SDKs don’t yet support retrieving file attachments or SSH keys, or using query parameters.
 
-1Password SDKs currently only support operations on text and concealed fields. As a result, you can't edit items that include information saved in other types of fields.
+1Password SDKs currently only support operations on text and concealed fields. As a result, you can’t edit items that include information saved in other types of fields.
 
 When managing items with 1Password SDKs, you must use [unique identifiers (IDs)](https://developer.1password.com/docs/sdks/concepts#unique-identifiers) in place of vault, item, and field names.
 


### PR DESCRIPTION
This MR fixes the first paragraph of the limitations section to clarify that you can't currently use the SDK to retrieve file attachments with secret references, rather than the current wording which implies you must use query parameters to retrieve files.