### PR TITLE
Inject zxcvbn time function

### DIFF
--- a/internal/imported.go
+++ b/internal/imported.go
@@ -12,7 +12,7 @@ import (
 
 // ImportedFunctions returns all functions 1Password SDK core must import.
 func ImportedFunctions() []extism.HostFunction {
-	return []extism.HostFunction{randomFillImportedFunc(), currentTimeImportedFunc()}
+	return []extism.HostFunction{randomFillImportedFunc(), currentTimeImportedFunc("op-now"), currentTimeImportedFunc("zxcvbn")}
 }
 
 // randomFillImportedFunc returns an Extism Function for generating random byte sequence of a given length that will be imported into the WASM core.
@@ -28,11 +28,11 @@ func randomFillImportedFunc() extism.HostFunction {
 }
 
 // getTimeFunc returns an Extism Function for retrieving the current UNIX time.
-func currentTimeImportedFunc() extism.HostFunction {
+func currentTimeImportedFunc(namespace string) extism.HostFunction {
 	getTimeFunc := extism.NewHostFunctionWithStack("unix_time_milliseconds_imported", func(ctx context.Context, p *extism.CurrentPlugin, stack []uint64) {
 		stack[0] = uint64(time.Now().UnixMilli())
 	}, []api.ValueType{}, []api.ValueType{api.ValueTypeI64})
-	getTimeFunc.SetNamespace("op-now")
+	getTimeFunc.SetNamespace(namespace)
 
 	return getTimeFunc
 }


### PR DESCRIPTION
In order to leverage the custom WASM import introduced in `zxcvbn` in https://github.com/shssoichiro/zxcvbn-rs/pull/83, the Go SDK is also required to export a function returning the UNIX milliseconds  under the `zxcvbn` namespace.

This is required for correctly calculating the password strength in the SDK core.