### PR TITLE
Document supported functionality in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,13 @@ Item/field Types:
 - [x] Passwords
 - [x] Logins
 - [x] Notes
+- [x] SSH Private Keys
+- [ ] SSH Public Keys
 - [ ] TOTP codes ([#93](https://github.com/1Password/onepassword-sdk-go/issues/93))
-- [ ] SSH Keys
 - [ ] Files / Documents ([#108](https://github.com/1Password/onepassword-sdk-go/issues/108))
-
+- [x] URLs
+- [x] Credit card number & type
+- [x] Phone numbers
 
 ### Vault Management
 - [ ] Retrieve Vaults

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Item/field Types:
 - [x] Passwords
 - [x] Logins
 - [x] Notes
-- [x] SSH Private Keys
+- [x] SSH Private Keys (partially supported: supported in resolving secret references, not yet supported in item create/get/update)
 - [ ] SSH Public Keys
 - [ ] TOTP codes ([#93](https://github.com/1Password/onepassword-sdk-go/issues/93))
 - [ ] Files / Documents ([#108](https://github.com/1Password/onepassword-sdk-go/issues/108))

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Item/field Types:
 ### Compliance & Reporting
 - [ ] WatchTower Insights
 - [ ] Travel Mode
-- [ ] Events. For now, check out using [1Password Events Reporting API](https://developer.1password.com/docs/events-api/) directly.
+- [ ] Events ([#76](https://github.com/1Password/onepassword-sdk-go/issues/76)). For now, check out using [1Password Events Reporting API](https://developer.1password.com/docs/events-api/) directly.
 
 ### Authentication
 

--- a/README.md
+++ b/README.md
@@ -14,59 +14,59 @@
 
 ---
 
-## Supported Functionality
+## Supported functionality
 
 1Password SDKs are in active development. We're keen to hear what you'd like to see next. Let us know by [upvoting](https://github.com/1Password/onepassword-sdk-go/issues) or [filing](https://github.com/1Password/onepassword-sdk-go/issues/new/choose) an issue.
 
-### Item Management
+### Item management
 Operations:
 - [x] [Retrieve secrets](https://developer.1password.com/docs/sdks/load-secrets)
-- [x] [Retrieve Items](https://developer.1password.com/docs/sdks/manage-items#get-an-item)
-- [x] [Create Items](https://developer.1password.com/docs/sdks/manage-items#create-an-item)
-- [x] [Update Items](https://developer.1password.com/docs/sdks/manage-items#edit-an-item)
-- [x] [Delete Items](https://developer.1password.com/docs/sdks/manage-items#delete-an-item)
-- [ ] List Items
-- [ ] Add & Update tags on items ([#86](https://github.com/1Password/onepassword-sdk-go/issues/86))
+- [x] [Retrieve items](https://developer.1password.com/docs/sdks/manage-items#get-an-item)
+- [x] [Create items](https://developer.1password.com/docs/sdks/manage-items#create-an-item)
+- [x] [Update items](https://developer.1password.com/docs/sdks/manage-items#edit-an-item)
+- [x] [Delete items](https://developer.1password.com/docs/sdks/manage-items#delete-an-item)
+- [ ] List items
+- [ ] Add & update tags on items ([#86](https://github.com/1Password/onepassword-sdk-go/issues/86))
 
-Item/field Types:
+Item/field types:
 - [x] API Keys
 - [x] Passwords
 - [x] Logins
 - [x] Notes
-- [x] SSH Private Keys (partially supported: supported in resolving secret references, not yet supported in item create/get/update)
-- [ ] SSH Public Keys
-- [ ] TOTP codes ([#93](https://github.com/1Password/onepassword-sdk-go/issues/93))
-- [ ] Files / Documents ([#108](https://github.com/1Password/onepassword-sdk-go/issues/108))
+- [x] SSH private keys (partially supported: supported in resolving secret references, not yet supported in item create/get/update)
+- [ ] SSH public keys
+- [ ] One-time passwords ([#93](https://github.com/1Password/onepassword-sdk-go/issues/93))
+- [ ] Files attachments and Document items ([#108](https://github.com/1Password/onepassword-sdk-go/issues/108))
 - [x] URLs
 - [x] Credit card number & type
 - [x] Phone numbers
 
-### Vault Management
-- [ ] Retrieve Vaults
-- [ ] Create Vaults
-- [ ] Update Vaults
-- [ ] Delete Vaults
-- [ ] List Vaults
+### Vault management
+- [ ] Retrieve vaults
+- [ ] Create vaults
+- [ ] Update vaults
+- [ ] Delete vaults
+- [ ] List vaults
 
-### User & Access Management
-- [ ] Provision Users
-- [ ] Retrieve Users
-- [ ] List Users
-- [ ] Suspend Users
-- [ ] Create Groups
-- [ ] Update Group Membership
-- [ ] Update Vault Access & Permissions
+### User & access management
+- [ ] Provision users
+- [ ] Retrieve users
+- [ ] List users
+- [ ] Suspend users
+- [ ] Create groups
+- [ ] Update group membership
+- [ ] Update vault access & permissions
 
-### Compliance & Reporting
-- [ ] WatchTower Insights
-- [ ] Travel Mode
-- [ ] Events ([#76](https://github.com/1Password/onepassword-sdk-go/issues/76)). For now, check out using [1Password Events Reporting API](https://developer.1password.com/docs/events-api/) directly.
+### Compliance & reporting
+- [ ] Watchtower insights
+- [ ] Travel mode
+- [ ] Events ([#76](https://github.com/1Password/onepassword-sdk-go/issues/76)). For now, use [1Password Events Reporting API](https://developer.1password.com/docs/events-api/) directly.
 
 ### Authentication
 
 - [x] [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/get-started/)
-- [ ] User Authentication
-- [ ] 1Password Connect. For now, use [1Password/connect-sdk-go](https://github.com/1Password/connect-sdk-go)
+- [ ] User authentication
+- [ ] 1Password Connect. For now, use [1Password/connect-sdk-go](https://github.com/1Password/connect-sdk-go).
 
 ## 🚀 Get started
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,56 @@
 
 ---
 
-The 1Password Go SDK offers programmatic access to your secrets in 1Password with Go. During the beta, you can create, retrieve, update, and delete items and resolve secret references.
+## Supported Functionality
 
-1Password SDKs support authentication with [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/get-started/). 
+1Password SDKs are in active development. We're keen to hear what you'd like to see next. Let us know by [upvoting](https://github.com/1Password/onepassword-sdk-go/issues) or [filing](https://github.com/1Password/onepassword-sdk-go/issues/new/choose) an issue.
 
-## ❗ Limitations
+### Item Management
+Operations:
+- [x] [Retrieve secrets](https://developer.1password.com/docs/sdks/load-secrets)
+- [x] [Retrieve Items](https://developer.1password.com/docs/sdks/manage-items#get-an-item)
+- [x] [Create Items](https://developer.1password.com/docs/sdks/manage-items#create-an-item)
+- [x] [Update Items](https://developer.1password.com/docs/sdks/manage-items#edit-an-item)
+- [x] [Delete Items](https://developer.1password.com/docs/sdks/manage-items#delete-an-item)
+- [ ] List Items
+- [ ] Add & Update tags on items ([#86](https://github.com/1Password/onepassword-sdk-go/issues/86))
 
-1Password SDKs don't yet support using secret references with query parameters, so you can't retrieve file attachments or SSH keys, or get more information about field metadata.
+Item/field Types:
+- [x] API Keys
+- [x] Passwords
+- [x] Logins
+- [x] Notes
+- [ ] TOTP codes ([#93](https://github.com/1Password/onepassword-sdk-go/issues/93))
+- [ ] SSH Keys
+- [ ] Files / Documents ([#108](https://github.com/1Password/onepassword-sdk-go/issues/108))
 
-1Password SDKs currently only support operations on text and concealed fields. As a result, you can't edit items that include information saved in other types of fields.
 
-When managing items with 1Password SDKs, you must use [unique identifiers (IDs)](https://developer.1password.com/docs/sdks/concepts#unique-identifiers) in place of vault, item, and field names.
+### Vault Management
+- [ ] Retrieve Vaults
+- [ ] Create Vaults
+- [ ] Update Vaults
+- [ ] Delete Vaults
+- [ ] List Vaults
+
+### User & Access Management
+- [ ] Provision Users
+- [ ] Retrieve Users
+- [ ] List Users
+- [ ] Suspend Users
+- [ ] Create Groups
+- [ ] Update Group Membership
+- [ ] Update Vault Access & Permissions
+
+### Compliance & Reporting
+- [ ] WatchTower Insights
+- [ ] Travel Mode
+- [ ] Events. For now, check out using [1Password Events Reporting API](https://developer.1password.com/docs/events-api/) directly.
+
+### Authentication
+
+- [x] [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/get-started/)
+- [ ] User Authentication
+- [ ] 1Password Connect. For now, use [1Password/connect-sdk-go](https://github.com/1Password/connect-sdk-go)
 
 ## 🚀 Get started
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ Operations:
 - [ ] List items
 - [ ] Add & update tags on items ([#86](https://github.com/1Password/onepassword-sdk-go/issues/86))
 
-Item/field types:
+Field types:
 - [x] API Keys
 - [x] Passwords
-- [x] Logins
+- [x] Concealed fields
+- [x] Text fields
 - [x] Notes
 - [x] SSH private keys (partially supported: supported in resolving secret references, not yet supported in item create/get/update)
-- [ ] SSH public keys
+- [ ] SSH public keys, fingerprint and key type
 - [ ] One-time passwords ([#93](https://github.com/1Password/onepassword-sdk-go/issues/93))
 - [ ] Files attachments and Document items ([#108](https://github.com/1Password/onepassword-sdk-go/issues/108))
 - [x] URLs


### PR DESCRIPTION
Make clear upfront what is and isn't yet supported in the README, and invite folks to contribute their desires by upvoting or filing issues.

I've changed the phrasing from "limitations" to a more roadmap-like todo list, to be more forward looking and bring across our intentions to continue expanding these SDKs across more use cases. I want it to be inviting to brainstorm or request additional use cases, and prevent these coming across as out of scope and SDKs not being suitable for these use cases.

Where there's existing issues already filed for functionality we don't support yet, I've included a link to the issue, so it's easier for folks to upvote this request if they need it too. We may even want to seed the issue tracker with issues for the other functionality, to make it even easier to indicate desire for these too. Before we do so, we may want to look into creating a central (core) repository first though, to track these, so that we're not duplicating issues for the same functionality across all repositories for the different languages, adding overhead to managing these issues and seeing demand across languages.

Where there's current alternatives available for programmatic access, I've listed these alternatives for easier discovery (e.g. Events API).