### PR TITLE
Change the way we call ClientInvoke due to new changes in SDK Core

### DIFF
--- a/client_builder.go
+++ b/client_builder.go
@@ -73,10 +73,12 @@ func WithIntegrationInfo(name string, version string) ClientOption {
 
 func clientInvoke(ctx context.Context, innerClient internal.InnerClient, invocation string, params map[string]interface{}) (*string, error) {
 	invocationResponse, err := innerClient.Core.Invoke(ctx, internal.InvokeConfig{
-		ClientID: innerClient.ID,
 		Invocation: internal.Invocation{
-			MethodName:       invocation,
-			SerializedParams: params,
+			ClientID: &innerClient.ID,
+			Parameters: internal.Parameters{
+				MethodName:       invocation,
+				SerializedParams: params,
+			},
 		},
 	})
 	if err != nil {

--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -90,10 +90,12 @@ func TestInvalidInvoke(t *testing.T) {
 
 	// invalid client id
 	invocation1 := internal.InvokeConfig{
-		ClientID: invalidClientID,
 		Invocation: internal.Invocation{
-			MethodName:       validMethodName,
-			SerializedParams: validParams,
+			ClientID: &invalidClientID,
+			Parameters: internal.Parameters{
+				MethodName:       validMethodName,
+				SerializedParams: validParams,
+			},
 		},
 	}
 	_, err1 := core.Invoke(context.Background(), invocation1)
@@ -101,20 +103,25 @@ func TestInvalidInvoke(t *testing.T) {
 
 	// invalid method name
 	invocation2 := internal.InvokeConfig{
-		ClientID: validClientID,
 		Invocation: internal.Invocation{
-			MethodName:       invalidMethodName,
-			SerializedParams: invalidParams,
+			ClientID: &validClientID,
+			Parameters: internal.Parameters{
+				MethodName:       invalidMethodName,
+				SerializedParams: invalidParams,
+			},
 		}}
 	_, err2 := core.Invoke(context.Background(), invocation2)
 	assert.NotNil(t, err2, "expected error when sending invocation that doesn't exist")
 
 	// invalid serialized params
 	invocation3 := internal.InvokeConfig{
-		ClientID: validClientID,
 		Invocation: internal.Invocation{
-			MethodName:       validMethodName,
-			SerializedParams: invalidParams,
+			ClientID: &validClientID,
+			Parameters: internal.Parameters{
+				MethodName:       validMethodName,
+				SerializedParams: invalidParams,
+			},
+
 		},
 	}
 	_, err3 := core.Invoke(context.Background(), invocation3)
@@ -127,12 +134,14 @@ func TestClientReleasedSuccessfully(t *testing.T) {
 
 	core, err := internal.GetSharedCore()
 	require.NoError(t, err)
-
+	clientID  := uint64(0)
 	invocation := internal.InvokeConfig{
-		ClientID: 0, // this client id should be invalid because the client has been cleaned up by GC
 		Invocation: internal.Invocation{
-			MethodName:       "SecretsResolve",
-			SerializedParams: map[string]interface{}{"secret_reference": "op://foo/bar/baz"},
+			ClientID: &clientID, // this client id should be invalid because the client has been cleaned up by GC
+			Parameters: internal.Parameters{
+				MethodName:       "SecretsResolve",
+				SerializedParams: map[string]interface{}{"secret_reference": "op://foo/bar/baz"},
+			},
 		},
 	}
 	_, err = core.Invoke(context.Background(), invocation)

--- a/internal/core.go
+++ b/internal/core.go
@@ -50,14 +50,18 @@ func NewDefaultConfig() ClientConfig {
 
 // InvokeConfig specifies over the FFI on which client the specified method should be invoked on.
 type InvokeConfig struct {
-	ClientID   uint64     `json:"clientId"`
 	Invocation Invocation `json:"invocation"`
+}
+
+type Parameters struct{
+	MethodName       string                 `json:"name"`
+	SerializedParams map[string]interface{} `json:"parameters"`
 }
 
 // Invocation holds the information required for invoking SDK functionality.
 type Invocation struct {
-	MethodName       string                 `json:"name"`
-	SerializedParams map[string]interface{} `json:"parameters"`
+	ClientID   *uint64     `json:"clientId,omitempty"`
+	Parameters Parameters `json:"parameters"`
 }
 
 // InnerClient represents the sdk-core client on which calls will be made.


### PR DESCRIPTION
Due to the upcoming changes in the SDK core, this PR will update the Go SDK to correctly call the `clientInvoke` method.