### PR TITLE
Add documentation delimiters to example file 

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -162,16 +162,16 @@ func createAndGetItem(client *onepassword.Client) onepassword.Item {
 	}
 	// [developer-docs.sdk.go.create-item]-end
 
-	// Retrieves the newly created item
 	// [developer-docs.sdk.go.get-item]-start
+	// Retrieves the newly created item
 	login, err := client.Items.Get(context.Background(), createdItem.VaultID, createdItem.ID)
 	if err != nil {
 		panic(err)
 	}
 	// [developer-docs.sdk.go.get-item]-end
 
-	// Retrieve TOTP code from an item
 	// [developer-docs.sdk.go.get-totp-item-crud]-start
+	// Retrieve TOTP code from an item
 	for _, f := range login.Fields {
 		if f.FieldType == onepassword.ItemFieldTypeTOTP {
 			OTPFieldDetails := f.Details.OTP()

--- a/example/main.go
+++ b/example/main.go
@@ -100,16 +100,15 @@ func getAndUpdateItem(client *onepassword.Client, existingVaultID, existingItemI
 }
 
 func resolveSecretReference(client *onepassword.Client, vaultID, itemID, fieldID string) {
+	// [developer-docs.sdk.go.resolve-secret]-start
 	// Retrieves a secret from 1Password.
 	// Takes a secret reference as input and returns the secret to which it points.
-	// [developer-docs.sdk.go.resolve-secret]-start
 	secret, err := client.Secrets.Resolve(context.Background(), fmt.Sprintf("op://%s/%s/%s", vaultID, itemID, fieldID))
 	if err != nil {
 		panic(err)
 	}
-	// [developer-docs.sdk.go.resolve-secret]-end
-
 	fmt.Println(secret)
+	// [developer-docs.sdk.go.resolve-secret]-end
 }
 
 func createAndGetItem(client *onepassword.Client) onepassword.Item {

--- a/example/main.go
+++ b/example/main.go
@@ -5,11 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"os"
-
-	"github.com/1password/onepassword-sdk-go"
 )
 
+// [developer-docs.sdk.go.sdk-import]-start
+import "github.com/1password/onepassword-sdk-go"
+
+// [developer-docs.sdk.go.sdk-import]-end
+
 func main() {
+	// [developer-docs.sdk.go.client-initialization]-start
 	// Gets your service account token from the OP_SERVICE_ACCOUNT_TOKEN environment variable.
 	token := os.Getenv("OP_SERVICE_ACCOUNT_TOKEN")
 
@@ -22,14 +26,19 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	// [developer-docs.sdk.go.client-initialization]-end
 
 	item := createAndGetItem(client)
 	getAndUpdateItem(client, item.VaultID, item.ID)
 	listVaultsAndItems(client)
 	resolveSecretReference(client, item.VaultID, item.ID, "username")
+
+	if !listVaultsAndItems(client) {
+
+	}
 }
 
-func listVaultsAndItems(client *onepassword.Client) {
+func listVaultsAndItems(client *onepassword.Client) bool {
 	vaults, err := client.Vaults.ListAll(context.Background())
 	if err != nil {
 		panic(err)
@@ -57,6 +66,7 @@ func listVaultsAndItems(client *onepassword.Client) {
 			fmt.Printf("%s %s\n", item.ID, item.Title)
 		}
 	}
+	return false
 }
 
 func getAndUpdateItem(client *onepassword.Client, existingVaultID, existingItemID string) {

--- a/types.go
+++ b/types.go
@@ -126,11 +126,6 @@ type ItemSection struct {
 	Title string `json:"title"`
 }
 
-type FieldsByName map[string]string
-type SectionsByName map[string]struct {
-	FieldsByName FieldsByName
-}
-
 // Represents a 1Password item.
 type Item struct {
 	// The item's ID
@@ -147,15 +142,6 @@ type Item struct {
 	Sections []ItemSection `json:"sections"`
 	// The item's version
 	Version uint32 `json:"version"`
-
-	FieldsByName   FieldsByName
-	SectionsByName SectionsByName
-}
-
-func main() {
-	item := Item{
-
-	}.SectionsByName["hello"].FieldsByName["there"]
 }
 type ItemCreateParams struct {
 	// The item's category

--- a/types.go
+++ b/types.go
@@ -126,6 +126,11 @@ type ItemSection struct {
 	Title string `json:"title"`
 }
 
+type FieldsByName map[string]string
+type SectionsByName map[string]struct {
+	FieldsByName FieldsByName
+}
+
 // Represents a 1Password item.
 type Item struct {
 	// The item's ID
@@ -142,6 +147,15 @@ type Item struct {
 	Sections []ItemSection `json:"sections"`
 	// The item's version
 	Version uint32 `json:"version"`
+
+	FieldsByName   FieldsByName
+	SectionsByName SectionsByName
+}
+
+func main() {
+	item := Item{
+
+	}.SectionsByName["hello"].FieldsByName["there"]
 }
 type ItemCreateParams struct {
 	// The item's category


### PR DESCRIPTION
In order to enable the automation of updating the SDK code snippets within the developer documentation, delimiters have to be added to logically separate different code blocks pertaining to functions of the SDK.