### PR TITLE
Point to GitHub Action commit SHA

### DIFF
--- a/.github/workflows/dependabot-pr-to-slack.yml
+++ b/.github/workflows/dependabot-pr-to-slack.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Slack Notification
-        uses: kv109/action-ready-for-review@0.2
+        uses: kv109/action-ready-for-review@76820bc668c3ce6c9be0c9322d07c2d8804dbd7a
         env:
           SLACK_CHANNEL: sdk-security-alerts
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/dependabot-vulns-to-slack.yml
+++ b/.github/workflows/dependabot-vulns-to-slack.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Vulnerabilities
-        uses: kunalnagarco/action-cve@v1.14.3
+        uses: kunalnagarco/action-cve@eb9224fc98e6eb9fbab701232c074a8d7c1598ca
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           slack_webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
Added reference to specific commit SHA instead of tags. The new links take me to the same page as the old ones, so I assume it's correct.