### PR TITLE
Improve paths to SDK IPC lib

### DIFF
--- a/internal/shared_lib_core.go
+++ b/internal/shared_lib_core.go
@@ -107,12 +107,6 @@ func find1PasswordLibPath() (string, error) {
 			"/snap/bin/1password/libop_sdk_ipc_client.so",
 		}
 
-	case "windows":
-		locations = []string{
-			`C:\Program Files\1Password\op_sdk_ipc_client.dll`,
-			`C:\Program Files (x86)\1Password\op_sdk_ipc_client.dll`,
-		}
-
 	default:
 		return "", fmt.Errorf("unsupported OS: %s", runtime.GOOS)
 	}


### PR DESCRIPTION
This PR does two changes:
- Make the paths to the SDK IPC client on Linux and MacOS more accurate
- Remove support for Windows. This will not be out yet during beta.