### PR TITLE
Reference inner client to persist client override

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ type Client struct {
 	GroupsAPI  GroupsAPI
 }
 
-func initAPIs(client *Client, inner internal.InnerClient) {
+func initAPIs(client *Client, inner *internal.InnerClient) {
 	client.SecretsAPI = NewSecretsSource(inner)
 	client.ItemsAPI = NewItemsSource(inner)
 	client.VaultsAPI = NewVaultsSource(inner)

--- a/client_builder.go
+++ b/client_builder.go
@@ -58,7 +58,7 @@ func initClient(ctx context.Context, core internal.CoreWrapper, client Client) (
 		Config: client.config,
 	}
 
-	initAPIs(&client, inner)
+	initAPIs(&client, &inner)
 
 	runtime.SetFinalizer(&client, func(f *Client) {
 		core.ReleaseClient(*clientID)

--- a/groups.go
+++ b/groups.go
@@ -15,15 +15,15 @@ type GroupsAPI interface {
 }
 
 type GroupsSource struct {
-	internal.InnerClient
+	*internal.InnerClient
 }
 
-func NewGroupsSource(inner internal.InnerClient) GroupsAPI {
+func NewGroupsSource(inner *internal.InnerClient) GroupsAPI {
 	return &GroupsSource{InnerClient: inner}
 }
 
 func (g GroupsSource) Get(ctx context.Context, groupID string, groupParams GroupGetParams) (Group, error) {
-	resultString, err := clientInvoke(ctx, &g.InnerClient, "GroupsGet", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, g.InnerClient, "GroupsGet", map[string]interface{}{
 		"group_id":     groupID,
 		"group_params": groupParams,
 	})

--- a/items.go
+++ b/items.go
@@ -44,12 +44,12 @@ type ItemsAPI interface {
 }
 
 type ItemsSource struct {
-	internal.InnerClient
+	*internal.InnerClient
 	SharesAPI ItemsSharesAPI
 	FilesAPI  ItemsFilesAPI
 }
 
-func NewItemsSource(inner internal.InnerClient) ItemsAPI {
+func NewItemsSource(inner *internal.InnerClient) ItemsAPI {
 	return &ItemsSource{InnerClient: inner, SharesAPI: NewItemsSharesSource(inner), FilesAPI: NewItemsFilesSource(inner)}
 }
 
@@ -62,7 +62,7 @@ func (i ItemsSource) Files() ItemsFilesAPI {
 
 // Create a new item.
 func (i ItemsSource) Create(ctx context.Context, params ItemCreateParams) (Item, error) {
-	resultString, err := clientInvoke(ctx, &i.InnerClient, "ItemsCreate", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, i.InnerClient, "ItemsCreate", map[string]interface{}{
 		"params": params,
 	})
 	if err != nil {
@@ -78,7 +78,7 @@ func (i ItemsSource) Create(ctx context.Context, params ItemCreateParams) (Item,
 
 // Create items in batch, within a single vault.
 func (i ItemsSource) CreateAll(ctx context.Context, vaultID string, params []ItemCreateParams) (ItemsUpdateAllResponse, error) {
-	resultString, err := clientInvoke(ctx, &i.InnerClient, "ItemsCreateAll", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, i.InnerClient, "ItemsCreateAll", map[string]interface{}{
 		"vault_id": vaultID,
 		"params":   params,
 	})
@@ -95,7 +95,7 @@ func (i ItemsSource) CreateAll(ctx context.Context, vaultID string, params []Ite
 
 // Get an item by vault and item ID
 func (i ItemsSource) Get(ctx context.Context, vaultID string, itemID string) (Item, error) {
-	resultString, err := clientInvoke(ctx, &i.InnerClient, "ItemsGet", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, i.InnerClient, "ItemsGet", map[string]interface{}{
 		"vault_id": vaultID,
 		"item_id":  itemID,
 	})
@@ -112,7 +112,7 @@ func (i ItemsSource) Get(ctx context.Context, vaultID string, itemID string) (It
 
 // Get items by vault and their item IDs.
 func (i ItemsSource) GetAll(ctx context.Context, vaultID string, itemIds []string) (ItemsGetAllResponse, error) {
-	resultString, err := clientInvoke(ctx, &i.InnerClient, "ItemsGetAll", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, i.InnerClient, "ItemsGetAll", map[string]interface{}{
 		"vault_id": vaultID,
 		"item_ids": itemIds,
 	})
@@ -129,7 +129,7 @@ func (i ItemsSource) GetAll(ctx context.Context, vaultID string, itemIds []strin
 
 // Update an existing item.
 func (i ItemsSource) Put(ctx context.Context, item Item) (Item, error) {
-	resultString, err := clientInvoke(ctx, &i.InnerClient, "ItemsPut", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, i.InnerClient, "ItemsPut", map[string]interface{}{
 		"item": item,
 	})
 	if err != nil {
@@ -145,7 +145,7 @@ func (i ItemsSource) Put(ctx context.Context, item Item) (Item, error) {
 
 // Delete an item.
 func (i ItemsSource) Delete(ctx context.Context, vaultID string, itemID string) error {
-	_, err := clientInvoke(ctx, &i.InnerClient, "ItemsDelete", map[string]interface{}{
+	_, err := clientInvoke(ctx, i.InnerClient, "ItemsDelete", map[string]interface{}{
 		"vault_id": vaultID,
 		"item_id":  itemID,
 	})
@@ -154,7 +154,7 @@ func (i ItemsSource) Delete(ctx context.Context, vaultID string, itemID string) 
 
 // Delete items in batch, within a single vault.
 func (i ItemsSource) DeleteAll(ctx context.Context, vaultID string, itemIds []string) (ItemsDeleteAllResponse, error) {
-	resultString, err := clientInvoke(ctx, &i.InnerClient, "ItemsDeleteAll", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, i.InnerClient, "ItemsDeleteAll", map[string]interface{}{
 		"vault_id": vaultID,
 		"item_ids": itemIds,
 	})
@@ -171,7 +171,7 @@ func (i ItemsSource) DeleteAll(ctx context.Context, vaultID string, itemIds []st
 
 // Archive an item.
 func (i ItemsSource) Archive(ctx context.Context, vaultID string, itemID string) error {
-	_, err := clientInvoke(ctx, &i.InnerClient, "ItemsArchive", map[string]interface{}{
+	_, err := clientInvoke(ctx, i.InnerClient, "ItemsArchive", map[string]interface{}{
 		"vault_id": vaultID,
 		"item_id":  itemID,
 	})
@@ -183,7 +183,7 @@ func (i ItemsSource) List(ctx context.Context, vaultID string, filters ...ItemLi
 	if filters == nil {
 		filters = []ItemListFilter{}
 	}
-	resultString, err := clientInvoke(ctx, &i.InnerClient, "ItemsList", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, i.InnerClient, "ItemsList", map[string]interface{}{
 		"vault_id": vaultID,
 		"filters":  filters,
 	})

--- a/items_files.go
+++ b/items_files.go
@@ -24,16 +24,16 @@ type ItemsFilesAPI interface {
 }
 
 type ItemsFilesSource struct {
-	internal.InnerClient
+	*internal.InnerClient
 }
 
-func NewItemsFilesSource(inner internal.InnerClient) ItemsFilesAPI {
+func NewItemsFilesSource(inner *internal.InnerClient) ItemsFilesAPI {
 	return &ItemsFilesSource{InnerClient: inner}
 }
 
 // Attach files to Items
 func (i ItemsFilesSource) Attach(ctx context.Context, item Item, fileParams FileCreateParams) (Item, error) {
-	resultString, err := clientInvoke(ctx, &i.InnerClient, "ItemsFilesAttach", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, i.InnerClient, "ItemsFilesAttach", map[string]interface{}{
 		"item":        item,
 		"file_params": fileParams,
 	})
@@ -50,7 +50,7 @@ func (i ItemsFilesSource) Attach(ctx context.Context, item Item, fileParams File
 
 // Read file content from the Item
 func (i ItemsFilesSource) Read(ctx context.Context, vaultID string, itemID string, attr FileAttributes) ([]byte, error) {
-	resultString, err := clientInvoke(ctx, &i.InnerClient, "ItemsFilesRead", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, i.InnerClient, "ItemsFilesRead", map[string]interface{}{
 		"vault_id": vaultID,
 		"item_id":  itemID,
 		"attr":     attr,
@@ -68,7 +68,7 @@ func (i ItemsFilesSource) Read(ctx context.Context, vaultID string, itemID strin
 
 // Delete a field file from Item using the section and field IDs
 func (i ItemsFilesSource) Delete(ctx context.Context, item Item, sectionID string, fieldID string) (Item, error) {
-	resultString, err := clientInvoke(ctx, &i.InnerClient, "ItemsFilesDelete", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, i.InnerClient, "ItemsFilesDelete", map[string]interface{}{
 		"item":       item,
 		"section_id": sectionID,
 		"field_id":   fieldID,
@@ -86,7 +86,7 @@ func (i ItemsFilesSource) Delete(ctx context.Context, item Item, sectionID strin
 
 // Replace the document file within a document item
 func (i ItemsFilesSource) ReplaceDocument(ctx context.Context, item Item, docParams DocumentCreateParams) (Item, error) {
-	resultString, err := clientInvoke(ctx, &i.InnerClient, "ItemsFilesReplaceDocument", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, i.InnerClient, "ItemsFilesReplaceDocument", map[string]interface{}{
 		"item":       item,
 		"doc_params": docParams,
 	})

--- a/items_shares.go
+++ b/items_shares.go
@@ -21,16 +21,16 @@ type ItemsSharesAPI interface {
 }
 
 type ItemsSharesSource struct {
-	internal.InnerClient
+	*internal.InnerClient
 }
 
-func NewItemsSharesSource(inner internal.InnerClient) ItemsSharesAPI {
+func NewItemsSharesSource(inner *internal.InnerClient) ItemsSharesAPI {
 	return &ItemsSharesSource{InnerClient: inner}
 }
 
 // Get the item sharing policy of your account.
 func (i ItemsSharesSource) GetAccountPolicy(ctx context.Context, vaultID string, itemID string) (ItemShareAccountPolicy, error) {
-	resultString, err := clientInvoke(ctx, &i.InnerClient, "ItemsSharesGetAccountPolicy", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, i.InnerClient, "ItemsSharesGetAccountPolicy", map[string]interface{}{
 		"vault_id": vaultID,
 		"item_id":  itemID,
 	})
@@ -47,7 +47,7 @@ func (i ItemsSharesSource) GetAccountPolicy(ctx context.Context, vaultID string,
 
 // Validate the recipients of an item sharing link.
 func (i ItemsSharesSource) ValidateRecipients(ctx context.Context, policy ItemShareAccountPolicy, recipients []string) ([]ValidRecipient, error) {
-	resultString, err := clientInvoke(ctx, &i.InnerClient, "ItemsSharesValidateRecipients", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, i.InnerClient, "ItemsSharesValidateRecipients", map[string]interface{}{
 		"policy":     policy,
 		"recipients": recipients,
 	})
@@ -64,7 +64,7 @@ func (i ItemsSharesSource) ValidateRecipients(ctx context.Context, policy ItemSh
 
 // Create a new item sharing link.
 func (i ItemsSharesSource) Create(ctx context.Context, item Item, policy ItemShareAccountPolicy, params ItemShareParams) (string, error) {
-	resultString, err := clientInvoke(ctx, &i.InnerClient, "ItemsSharesCreate", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, i.InnerClient, "ItemsSharesCreate", map[string]interface{}{
 		"item":   item,
 		"policy": policy,
 		"params": params,

--- a/secrets.go
+++ b/secrets.go
@@ -20,10 +20,10 @@ type SecretsAPI interface {
 }
 
 type SecretsSource struct {
-	internal.InnerClient
+	*internal.InnerClient
 }
 
-func NewSecretsSource(inner internal.InnerClient) SecretsAPI {
+func NewSecretsSource(inner *internal.InnerClient) SecretsAPI {
 	return &SecretsSource{InnerClient: inner}
 }
 
@@ -33,7 +33,7 @@ var Secrets = secretsUtil{}
 
 // Resolve returns the secret the provided secret reference points to.
 func (s SecretsSource) Resolve(ctx context.Context, secretReference string) (string, error) {
-	resultString, err := clientInvoke(ctx, &s.InnerClient, "SecretsResolve", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, s.InnerClient, "SecretsResolve", map[string]interface{}{
 		"secret_reference": secretReference,
 	})
 	if err != nil {
@@ -49,7 +49,7 @@ func (s SecretsSource) Resolve(ctx context.Context, secretReference string) (str
 
 // Resolve takes in a list of secret references and returns the secrets they point to or errors if any.
 func (s SecretsSource) ResolveAll(ctx context.Context, secretReferences []string) (ResolveAllResponse, error) {
-	resultString, err := clientInvoke(ctx, &s.InnerClient, "SecretsResolveAll", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, s.InnerClient, "SecretsResolveAll", map[string]interface{}{
 		"secret_references": secretReferences,
 	})
 	if err != nil {

--- a/vaults.go
+++ b/vaults.go
@@ -26,10 +26,10 @@ type VaultsAPI interface {
 }
 
 type VaultsSource struct {
-	internal.InnerClient
+	*internal.InnerClient
 }
 
-func NewVaultsSource(inner internal.InnerClient) VaultsAPI {
+func NewVaultsSource(inner *internal.InnerClient) VaultsAPI {
 	return &VaultsSource{InnerClient: inner}
 }
 
@@ -39,7 +39,7 @@ func (v VaultsSource) List(ctx context.Context, params ...VaultListParams) ([]Va
 	if len(params) > 0 {
 		param = params[0]
 	}
-	resultString, err := clientInvoke(ctx, &v.InnerClient, "VaultsList", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, v.InnerClient, "VaultsList", map[string]interface{}{
 		"params": param,
 	})
 	if err != nil {
@@ -54,7 +54,7 @@ func (v VaultsSource) List(ctx context.Context, params ...VaultListParams) ([]Va
 }
 
 func (v VaultsSource) GetOverview(ctx context.Context, vaultUuid string) (VaultOverview, error) {
-	resultString, err := clientInvoke(ctx, &v.InnerClient, "VaultsGetOverview", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, v.InnerClient, "VaultsGetOverview", map[string]interface{}{
 		"vault_uuid": vaultUuid,
 	})
 	if err != nil {
@@ -69,7 +69,7 @@ func (v VaultsSource) GetOverview(ctx context.Context, vaultUuid string) (VaultO
 }
 
 func (v VaultsSource) Get(ctx context.Context, vaultUuid string, vaultParams VaultGetParams) (Vault, error) {
-	resultString, err := clientInvoke(ctx, &v.InnerClient, "VaultsGet", map[string]interface{}{
+	resultString, err := clientInvoke(ctx, v.InnerClient, "VaultsGet", map[string]interface{}{
 		"vault_uuid":   vaultUuid,
 		"vault_params": vaultParams,
 	})
@@ -85,7 +85,7 @@ func (v VaultsSource) Get(ctx context.Context, vaultUuid string, vaultParams Vau
 }
 
 func (v VaultsSource) GrantGroupPermissions(ctx context.Context, vaultID string, groupPermissionsList []GroupAccess) error {
-	_, err := clientInvoke(ctx, &v.InnerClient, "VaultsGrantGroupPermissions", map[string]interface{}{
+	_, err := clientInvoke(ctx, v.InnerClient, "VaultsGrantGroupPermissions", map[string]interface{}{
 		"vault_id":               vaultID,
 		"group_permissions_list": groupPermissionsList,
 	})
@@ -93,14 +93,14 @@ func (v VaultsSource) GrantGroupPermissions(ctx context.Context, vaultID string,
 }
 
 func (v VaultsSource) UpdateGroupPermissions(ctx context.Context, groupPermissionsList []GroupVaultAccess) error {
-	_, err := clientInvoke(ctx, &v.InnerClient, "VaultsUpdateGroupPermissions", map[string]interface{}{
+	_, err := clientInvoke(ctx, v.InnerClient, "VaultsUpdateGroupPermissions", map[string]interface{}{
 		"group_permissions_list": groupPermissionsList,
 	})
 	return err
 }
 
 func (v VaultsSource) RevokeGroupPermissions(ctx context.Context, vaultID string, groupID string) error {
-	_, err := clientInvoke(ctx, &v.InnerClient, "VaultsRevokeGroupPermissions", map[string]interface{}{
+	_, err := clientInvoke(ctx, v.InnerClient, "VaultsRevokeGroupPermissions", map[string]interface{}{
 		"vault_id": vaultID,
 		"group_id": groupID,
 	})


### PR DESCRIPTION
## Summary

This PR addressed the following bug found in the version `0.4.0-beta.2`:
_A program running the SDK initializes a new client that authenticates via the Desktop app. After the client is initialized, the Desktop app gets locked. User will be re-prompted to authorize the SDK. The SDK will re-initialize a new client and the API that performed the operation (e.g. `Items()`) will have the latest client. However, the other APIs will still use the expired client._

## Thought process

Instead of passing the `innerClient` as a value to the APIs, we pass a reference to it.

## How to test

For this you'll need:
- A 1Password Business account.
- A vault ID
- A group ID

1. Replace the `example/desktop_app/main.go` with this snippet:
   ```go
   package main

   import (
	   "context"
	   "fmt"
	   "log"
	   "os"
	   "time"
  
	   "github.com/1password/onepassword-sdk-go"
   )


   func main() {
	   // Connects to the 1Password Desktop app.
	   client, err := onepassword.NewClient(context.Background(),
		    onepassword.WithDesktopAppIntegration("YourAccountNameAsShownInTheDesktopApp"),
		    // TODO: Set the following to your own integration name and version.
		    onepassword.WithIntegrationInfo("My 1Password Integration", "v1.0.0"),
	   )
	   if err != nil {
		    panic(err)
	   }

	   vaultID := os.Getenv("OP_VAULT_ID")
	   if vaultID == "" {
		    panic("OP_VAULT_ID is required")
	   }

	   interval := 30 * time.Second
	   totalDuration := 1 * time.Minute
	   endTime := time.Now().Add(totalDuration)

	   for time.Now().Before(endTime) {
		    _, err := client.Vaults().List(context.Background())
		    if err != nil {
			    log.Printf("❌ Function failed: %v\n", err)
		    } else {
			    log.Println("✅ Function succeeded")
		    }

		    // Wait for next run unless we're out of time
		    if next := time.Now().Add(interval); next.Before(endTime) {
			    log.Println("Sleeping until next operation. Lock the app...")
			    time.Sleep(interval)
		    } else {
			    break
		    }
	   }

	   groupID := os.Getenv("OP_GROUP_ID")
	   if groupID == "" {
		    panic("OP_GROUP_ID is required")
	   }

	   // Get a group
	   group, err := client.Groups().Get(context.Background(), groupID, onepassword.GroupGetParams{})
	   if err != nil {
		    fmt.Printf("❌ Getting group failed: %v\n", err)
		    return
	   }
	   fmt.Println("✅ Getting group succeeded")
   }
   ```

   Note: Don't forget to replace `YourAccountNameAsShownInTheDesktopApp` with your account name.
2. Export `OP_VAULT_ID` and `OP_GROUP_ID` environment variables.
3. Run the example:
    ```sh
    go run example/desktop_app/main.go
    ```

4. While the program hangs, lock the app.
5. Re-authorize when prompted again.
    - [ ] The `Groups().Get()` operation should now succeed.