### PR TITLE
Support loading a custom shared library path.

### DIFF
--- a/client_builder.go
+++ b/client_builder.go
@@ -94,8 +94,8 @@ func WithDesktopAppIntegration(accountName string) ClientOption {
 	}
 }
 
-// WithCustomSharedLibraryPath specifies a custom path to load the shared library (dll/dylib/so) file from
-func WithCustomSharedLibraryPath(path string) ClientOption {
+// WithSharedLibraryPath specifies a custom path to load the shared library (dll/dylib/so) file from
+func WithSharedLibraryPath(path string) ClientOption {
 	return func(c *Client) error {
 		c.config.SharedLibraryPath = path
 		return nil

--- a/client_builder.go
+++ b/client_builder.go
@@ -34,7 +34,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
 	var core *internal.CoreWrapper
 	var err error
 	if client.config.AccountName != nil {
-		core, err = internal.GetSharedLibCore(*client.config.AccountName)
+		core, err = internal.GetSharedLibCore(*client.config.AccountName, client.config.SharedLibraryPath)
 	} else {
 		core, err = internal.GetExtismCore()
 	}
@@ -90,6 +90,14 @@ func WithIntegrationInfo(name string, version string) ClientOption {
 func WithDesktopAppIntegration(accountName string) ClientOption {
 	return func(c *Client) error {
 		c.config.AccountName = &accountName
+		return nil
+	}
+}
+
+// WithCustomSharedLibraryPath specifies a custom path to load the shared library (dll/dylib/so) file from
+func WithCustomSharedLibraryPath(path string) ClientOption {
+	return func(c *Client) error {
+		c.config.SharedLibraryPath = path
 		return nil
 	}
 }

--- a/internal/core.go
+++ b/internal/core.go
@@ -80,6 +80,7 @@ type ClientConfig struct {
 	SAToken               string  `json:"serviceAccountToken"`
 	Language              string  `json:"programmingLanguage"`
 	SDKVersion            string  `json:"sdkVersion"`
+	SharedLibraryPath     string  `json:"sharedLibraryPath"`
 	IntegrationName       string  `json:"integrationName"`
 	IntegrationVersion    string  `json:"integrationVersion"`
 	RequestLibraryName    string  `json:"requestLibraryName"`

--- a/internal/shared_lib_core.go
+++ b/internal/shared_lib_core.go
@@ -59,6 +59,9 @@ func find1PasswordLibPath() (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported OS: %s", runtime.GOOS)
 	}
+	if libPath := os.Getenv("OP_SHARED_LIB_PATH"); libPath != "" {
+		locations = append([]string{libPath}, locations...)
+	}
 	for _, libPath := range locations {
 		if _, err := os.Stat(libPath); err == nil {
 			return libPath, nil

--- a/internal/shared_lib_core.go
+++ b/internal/shared_lib_core.go
@@ -26,7 +26,7 @@ func (r Response) Error() string { return string(r.Payload) }
 
 // find1PasswordLibPath returns the path to the 1Password shared library
 // (libop_sdk_ipc_client.dylib/.so/.dll) depending on OS.
-func find1PasswordLibPath() (string, error) {
+func find1PasswordLibPath(customLocation string) (string, error) {
 	var locations []string
 
 	home, err := os.UserHomeDir()
@@ -59,8 +59,8 @@ func find1PasswordLibPath() (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported OS: %s", runtime.GOOS)
 	}
-	if libPath := os.Getenv("OP_SHARED_LIB_PATH"); libPath != "" {
-		locations = append([]string{libPath}, locations...)
+	if customLocation != "" {
+		locations = append([]string{customLocation}, locations...)
 	}
 	for _, libPath := range locations {
 		if _, err := os.Stat(libPath); err == nil {
@@ -71,9 +71,9 @@ func find1PasswordLibPath() (string, error) {
 	return "", fmt.Errorf("1Password desktop application not found")
 }
 
-func GetSharedLibCore(accountName string) (*CoreWrapper, error) {
+func GetSharedLibCore(accountName string, libraryPath string) (*CoreWrapper, error) {
 	if coreLib == nil {
-		libPath, err := find1PasswordLibPath()
+		libPath, err := find1PasswordLibPath(libraryPath)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
~~Adds an environment variable `OP_SHARED_LIB_PATH` to support loading a custom shared library file location.~~

Adds a `WithSharedLibraryPath` option to support loading a custom shared library file location.

This is useful for sandboxed contexts (such as nix) which don't have access to the /opt/1Password (or other) directory and must copy the library into the sandbox.

Related SDK PRs:
- https://github.com/1Password/onepassword-sdk-js/pull/169
- https://github.com/1Password/onepassword-sdk-python/pull/198