### PR TITLE
Add an example that's specific to environments read SDK

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,23 +4,22 @@ name: Validate
 on:
   push:
     paths-ignore:
-      - '**.md'
+      - "**.md"
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 jobs:
-
   test:
     name: Build & Test
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         # supported versions at the time of writing (Nov. 3rd, 2025)
         # https://go.dev/dl/
-        go-version: [ '1.24', '1.25' ]
+        go-version: ["1.24", "1.25"]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
 
@@ -40,10 +39,10 @@ jobs:
 
       - name: Unit Test
         run: go test -v ./internal/...
-  
+
   example_test:
     name: Run Example Code
-    needs: test  
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -61,7 +60,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '^1.24'
+          go-version: "^1.24"
 
       - name: Check out code
         uses: actions/checkout@v6

--- a/example/desktop_app/main.go
+++ b/example/desktop_app/main.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/1password/onepassword-sdk-go"
 )
 
 // [developer-docs.sdk.go.sdk-import]-start
-import "github.com/1password/onepassword-sdk-go"
 
 // [developer-docs.sdk.go.sdk-import]-end
 
@@ -49,20 +50,6 @@ func main() {
 	}
 	fmt.Printf("Group details: %v\n", group)
 	// [developer-docs.sdk.go.get-group]-end
-
-	environmentID := os.Getenv("OP_ENVIRONMENT_ID")
-	if environmentID != "" {
-		// [developer-docs.sdk.go.get-environment-variables]-start
-		// Read variables from a 1Password Environment
-		environment, err := client.Environments().GetVariables(context.Background(), environmentID)
-		if err != nil {
-			panic(err)
-		}
-		for _, variable := range environment.Variables {
-			fmt.Printf("%s: %s (masked: %t)\n", variable.Name, variable.Value, variable.Masked)
-		}
-		// [developer-docs.sdk.go.get-environment-variables]-end
-	}
 }
 
 func createAndGetItem(client *onepassword.Client, vaultID string) onepassword.Item {

--- a/example/environments/README.md
+++ b/example/environments/README.md
@@ -1,0 +1,47 @@
+# Read 1Password Environments
+
+This example shows how to read environment variables from a [1Password Environment](https://developer.1password.com/docs/sdks/environments/) using the Go SDK.
+
+## Prerequisites
+
+1. Clone the repository and follow the [get started](https://github.com/1Password/onepassword-sdk-go#-get-started) steps.
+2. Get your Environment ID from the 1Password app:
+   - Open the 1Password desktop app and unlock it.
+   - Go to **Developer** > **View Environments**.
+   - Select **View environment** next to the Environment you want to use.
+   - Select **Manage environment** > **Copy environment ID**.
+
+   **Tip:** To see the Environment ID in the 'manage environment' dropdown, enable **Show debugging tools** under **Application** > **Settings** > **Advanced**. You may need to log out and back in for this setting to take effect.
+
+## Authentication
+
+Use either a service account or the 1Password desktop app.
+
+**Service account:**
+
+```bash
+export OP_SERVICE_ACCOUNT_TOKEN="<your token>"
+```
+
+**Desktop app:** Set your account name as shown in the desktop app:
+
+```bash
+export OP_ACCOUNT_NAME="<your account name>"
+```
+
+## How to run
+
+Set the Environment ID, then run the example from the project root:
+
+```bash
+export OP_ENVIRONMENT_ID="<your environment id>"
+go run example/environments/main.go
+```
+
+## Output
+
+The program prints each variable in the environment, including its name, value, and whether its value is hidden by default in the 1Password app.
+
+## Documentation
+
+- [Read 1Password Environments (SDK guide)](https://developer.1password.com/docs/sdks/environments/)

--- a/example/environments/README.md
+++ b/example/environments/README.md
@@ -9,9 +9,7 @@ This example shows how to read environment variables from a [1Password Environme
    - Open the 1Password desktop app and unlock it.
    - Go to **Developer** > **View Environments**.
    - Select **View environment** next to the Environment you want to use.
-   - Select **Manage environment** > **Copy environment ID**.
-
-   **Tip:** To see the Environment ID in the 'manage environment' dropdown, enable **Show debugging tools** under **Application** > **Settings** > **Advanced**. You may need to log out and back in for this setting to take effect.
+   - Select the **vertical ellipsis button** > **Copy environment ID**.
 
 ## Authentication
 

--- a/example/environments/README.md
+++ b/example/environments/README.md
@@ -1,11 +1,11 @@
 # Read 1Password Environments
 
-This example shows how to read environment variables from a [1Password Environment](https://developer.1password.com/docs/sdks/environments/) using the Go SDK.
+This example shows how to read environment variables from a [1Password Environment](https://1password.dev/sdks/environments/) using the Go SDK.
 
 ## Prerequisites
 
 1. Clone the repository and follow the [get started](https://github.com/1Password/onepassword-sdk-go#-get-started) steps.
-2. Get your Environment ID from the 1Password app:
+2. Get your environment ID from the 1Password app:
    - Open the 1Password desktop app and unlock it.
    - Go to **Developer** > **View Environments**.
    - Select **View environment** next to the Environment you want to use.
@@ -29,7 +29,7 @@ export OP_ACCOUNT_NAME="<your account name>"
 
 ## How to run
 
-Set the Environment ID, then run the example from the project root:
+Set the environment ID, then run the example from the project root:
 
 ```bash
 export OP_ENVIRONMENT_ID="<your environment id>"
@@ -42,4 +42,4 @@ The program prints each variable in the environment, including its name, value, 
 
 ## Documentation
 
-- [Read 1Password Environments (SDK guide)](https://developer.1password.com/docs/sdks/environments/)
+- [Read 1Password Environments (SDK guide)](https://1password.dev/sdks/environments/)

--- a/example/environments/main.go
+++ b/example/environments/main.go
@@ -1,0 +1,58 @@
+// This example demonstrates reading environment variables from a 1Password Environment
+// using the Go SDK. See: https://developer.1password.com/docs/sdks/environments/
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/1password/onepassword-sdk-go"
+)
+
+func main() {
+	environmentID := os.Getenv("OP_ENVIRONMENT_ID")
+	if environmentID == "" {
+		fmt.Fprintln(os.Stderr, "OP_ENVIRONMENT_ID is required. Get your Environment ID from the 1Password app:")
+		fmt.Fprintln(os.Stderr, "  Developer > View Environments > Manage environment > Copy environment ID")
+		os.Exit(1)
+	}
+
+	client, err := newClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create client: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Read variables from the 1Password Environment
+	response, err := client.Environments().GetVariables(context.Background(), environmentID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "GetVariables failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Environment has %d variable(s):\n", len(response.Variables))
+	for _, v := range response.Variables {
+		fmt.Printf("  %s = %s (masked: %t)\n", v.Name, v.Value, v.Masked)
+	}
+}
+
+func newClient() (*onepassword.Client, error) {
+	ctx := context.Background()
+
+	if token := os.Getenv("OP_SERVICE_ACCOUNT_TOKEN"); token != "" {
+		return onepassword.NewClient(ctx,
+			onepassword.WithServiceAccountToken(token),
+			onepassword.WithIntegrationInfo("Environments Example", "1.0.0"),
+		)
+	}
+
+	accountName := os.Getenv("OP_ACCOUNT_NAME")
+	if accountName == "" {
+		accountName = "YourAccountNameAsShownInTheDesktopApp"
+	}
+	return onepassword.NewClient(ctx,
+		onepassword.WithDesktopAppIntegration(accountName),
+		onepassword.WithIntegrationInfo("Environments Example", "1.0.0"),
+	)
+}

--- a/example/environments/main.go
+++ b/example/environments/main.go
@@ -1,5 +1,5 @@
 // This example demonstrates reading environment variables from a 1Password Environment
-// using the 1Password Go SDK. See: https://developer.1password.com/docs/sdks/environments/
+// using the 1Password Go SDK. See: https://1password.dev/sdks/environments/
 package main
 
 import (
@@ -14,7 +14,7 @@ func main() {
 	environmentID := os.Getenv("OP_ENVIRONMENT_ID")
 	if environmentID == "" {
 		fmt.Fprintln(os.Stderr, "OP_ENVIRONMENT_ID is required. You can find your Environment ID from the 1Password app:")
-		fmt.Fprintln(os.Stderr, "  Developer > View Environments > Manage environment > Copy environment ID")
+		fmt.Fprintln(os.Stderr, `Navigate to: Developer > View Environments > Select "View Environment" for the desired environment > Click the vertical ellipsis button > Select "Copy environment ID"`)
 		os.Exit(1)
 	}
 

--- a/example/environments/main.go
+++ b/example/environments/main.go
@@ -1,5 +1,5 @@
 // This example demonstrates reading environment variables from a 1Password Environment
-// using the Go SDK. See: https://developer.1password.com/docs/sdks/environments/
+// using the 1Password Go SDK. See: https://developer.1password.com/docs/sdks/environments/
 package main
 
 import (
@@ -13,7 +13,7 @@ import (
 func main() {
 	environmentID := os.Getenv("OP_ENVIRONMENT_ID")
 	if environmentID == "" {
-		fmt.Fprintln(os.Stderr, "OP_ENVIRONMENT_ID is required. Get your Environment ID from the 1Password app:")
+		fmt.Fprintln(os.Stderr, "OP_ENVIRONMENT_ID is required. You can find your Environment ID from the 1Password app:")
 		fmt.Fprintln(os.Stderr, "  Developer > View Environments > Manage environment > Copy environment ID")
 		os.Exit(1)
 	}


### PR DESCRIPTION
This PR adds an example of using an environments read operation. It's a more specific implementation of what lives in the existing `service_accounts` example. 

I tested it with a service account and a environment configured in my 1P test instance:
```
➜  environments git:(malnick/v-0.4.1-beta.1) ✗ go run main.go
Environment has 1 variable(s):
  TEST = test-value (masked: true)
```

I appreciate any feedback, big thanks to @schneedotdev for the support!