### PR TITLE
fix: cgo handling in the code base

### DIFF
--- a/client_builder_no_cgo.go
+++ b/client_builder_no_cgo.go
@@ -2,8 +2,11 @@
 
 package onepassword
 
+import "fmt"
+
 // WithDesktopAppIntegration specifies a client should use the desktop app to authenticate. Set to your 1Password account name as shown at the top left sidebar of the app, or your account UUID.
 func WithDesktopAppIntegration(accountName string) ClientOption {
-	var _ = ERROR_WithDesktopAppIntegration_requires_CGO_To_Cross_Compile_See_README_CGO_Section
-	return nil
+	return func(c *Client) error {
+		return fmt.Errorf("WithDesktopAppIntegration requires CGO to cross-compile. See README CGO section")
+	}
 }

--- a/client_builder_no_cgo.go
+++ b/client_builder_no_cgo.go
@@ -2,11 +2,11 @@
 
 package onepassword
 
-import "fmt"
+import "errors"
 
 // WithDesktopAppIntegration specifies a client should use the desktop app to authenticate. Set to your 1Password account name as shown at the top left sidebar of the app, or your account UUID.
 func WithDesktopAppIntegration(accountName string) ClientOption {
 	return func(c *Client) error {
-		return fmt.Errorf("WithDesktopAppIntegration requires CGO to cross-compile. See README CGO section")
+		return errors.New("WithDesktopAppIntegration requires CGO to cross-compile. See README CGO section")
 	}
 }

--- a/internal/shared_lib_core_unix.go
+++ b/internal/shared_lib_core_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || linux
+//go:build cgo && (darwin || linux)
 
 package internal
 


### PR DESCRIPTION
add missing build tag to shared_lib_core_unix (to match its
companion file).

fix the client_builder_no_cgo to return a runtime error, instead
of using an undefined symbol to produce a compile error. the
problem (IMHO, of course) is that this will not let me "build"
otherwise.

resolves: #260
