### PR TITLE
Add ok-to-test workflow for fork PRs

### DIFF
--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -1,0 +1,23 @@
+# Write "/ok-to-test sha=<hash>" on a pull request to trigger integration tests.
+name: Ok To Test
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  ok-to-test:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    if: ${{ github.event.issue.pull_request }}
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-type: pull-request
+          commands: ok-to-test
+          permission: write

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,7 @@ name: Validate
 
 on:
   push:
+    branches: [main]
     paths-ignore:
       - '**.md'
   pull_request:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,11 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+  # Triggered by ok-to-test.yml when a maintainer comments "/ok-to-test" on a fork PR.
+  # On repository_dispatch, github.sha is the default branch HEAD — not the PR commit.
+  # The actual PR head SHA comes from client_payload.pull_request.head.sha.
+  repository_dispatch:
+    types: [ok-to-test-command]
 
 jobs:
 
@@ -23,6 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # On repository_dispatch, check out the exact SHA the maintainer reviewed.
+          # Prevents TOCTOU: fork author could force-push between review and checkout.
+          # Empty string falls back to the default ref (correct for push/pull_request).
+          ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.pull_request.head.sha || '' }}
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -55,6 +65,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.pull_request.head.sha || '' }}
 
       - name: Run Example Test
         run: go run example/service_account/main.go
@@ -73,6 +85,30 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.pull_request.head.sha || '' }}
 
       - name: Lint with golanci-lint
         uses: golangci/golangci-lint-action@v9
+
+  comment-result:
+    name: Comment Result on PR
+    if: ${{ always() && github.event_name == 'repository_dispatch' }}
+    needs: [test, example_test, golangci]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: peter-evans/create-or-update-comment@v5
+        with:
+          issue-number: ${{ github.event.client_payload.pull_request.number }}
+          body: |
+            `/ok-to-test` result: **${{ (needs.test.result == 'success' && needs.example_test.result == 'success' && needs.golangci.result == 'success') && 'All checks passed ✅' || 'Some checks failed ❌' }}**
+
+            | Job | Result |
+            |-----|--------|
+            | Build & Test | `${{ needs.test.result }}` |
+            | Example Test | `${{ needs.example_test.result }}` |
+            | Lint | `${{ needs.golangci.result }}` |
+
+            [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,7 +33,11 @@ jobs:
         run: go build -v ./...
 
       - name: Integration Test
-        if: github.repository_owner == '1Password' # don't run integration tests on forked PRs because those don't have access to pipeline secrets
+        # Run when secrets are available: push (always internal), internal PRs, or /ok-to-test dispatch.
+        # Skips on fork pull_request events where secrets are withheld.
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.TEST_SA_TOKEN }}
         run: go test -v ./integration_tests/...
@@ -43,7 +47,11 @@ jobs:
   
   example_test:
     name: Run Example Code
-    needs: test  
+    needs: test
+    # Same fork guard — example tests require secrets.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,8 +9,8 @@ on:
     paths-ignore:
       - '**.md'
   # Triggered by ok-to-test.yml when a maintainer comments "/ok-to-test" on a fork PR.
-  # On repository_dispatch, github.sha is the default branch HEAD — not the PR commit.
-  # The actual PR head SHA comes from client_payload.pull_request.head.sha.
+  # github.sha resolves to the default branch here, so jobs check out
+  # client_payload.pull_request.head.sha instead.
   repository_dispatch:
     types: [ok-to-test-command]
 
@@ -29,9 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # On repository_dispatch, check out the exact SHA the maintainer reviewed.
-          # Prevents TOCTOU: fork author could force-push between review and checkout.
-          # Empty string falls back to the default ref (correct for push/pull_request).
+          # Pin to the SHA the maintainer reviewed. Empty string uses the default ref.
           ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.pull_request.head.sha || '' }}
 
       - name: Set up Go
@@ -43,10 +41,10 @@ jobs:
         run: go build -v ./...
 
       - name: Integration Test
-        # Run when secrets are available: push (always internal), internal PRs, or /ok-to-test dispatch.
-        # Skips on fork pull_request events where secrets are withheld.
+        # Skip fork PRs — they can't access pipeline secrets.
         if: >-
-          github.event_name != 'pull_request' ||
+          github.event_name == 'push' ||
+          github.event_name == 'repository_dispatch' ||
           github.event.pull_request.head.repo.full_name == github.repository
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.TEST_SA_TOKEN }}
@@ -60,7 +58,8 @@ jobs:
     needs: test
     # Same fork guard — example tests require secrets.
     if: >-
-      github.event_name != 'pull_request' ||
+      github.event_name == 'push' ||
+      github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fork PRs can't currently run CI. Integration tests fail for lack of secrets.

This PR adds the standard `/ok-to-test` slash command workflow so maintainers can explicitly run integration tests against fork PR code after review via `repository_dispatch`. On dispatch, checkout uses `client_payload.pull_request.head.sha` to check out the exact reviewed commit.

Smoke-tested against #263's head SHA in a [test run](https://github.com/1Password/onepassword-sdk-go/actions/runs/24400168573).
