### PR TITLE
fix: return runtime error instead of compile-time trap in no-cgo build

### DIFF
--- a/client_builder_no_cgo.go
+++ b/client_builder_no_cgo.go
@@ -2,8 +2,11 @@
 
 package onepassword
 
+import "fmt"
+
 // WithDesktopAppIntegration specifies a client should use the desktop app to authenticate. Set to your 1Password account name as shown at the top left sidebar of the app, or your account UUID.
 func WithDesktopAppIntegration(accountName string) ClientOption {
-	var _ = ERROR_WithDesktopAppIntegration_requires_CGO_To_Cross_Compile_See_README_CGO_Section
-	return nil
+	return func(c *Client) error {
+		return fmt.Errorf("the desktop app integration feature requires CGO (CGO_ENABLED=1 and a working C toolchain - see README.md for how to build this)")
+	}
 }


### PR DESCRIPTION
The undefined symbol trick in WithDesktopAppIntegration broke compilation under CGO_ENABLED=0 even when the function was never called, since the symbol reference is type-checked unconditionally. Match the pattern used in internal/shared_lib_core_no_cgo.go and return a runtime error instead.

This fixes compilation without CGO.