### PR TITLE
fix: synchronize Extism core initialization

### DIFF
--- a/internal/extism_core.go
+++ b/internal/extism_core.go
@@ -23,17 +23,38 @@ const (
 	releaseClientFuncName = "release_client"
 )
 
-var core *ExtismCore
+var (
+	coreMu sync.Mutex
+	core   *ExtismCore
+)
 
 // GetExtismCore initializes the shared core once and returns the already existing one on subsequent calls.
 func GetExtismCore() (*CoreWrapper, error) {
-	runtimeCtx := context.Background()
-	if core == nil {
+	return getExtismCore(func() (*ExtismCore, error) {
+		runtimeCtx := context.Background()
 		p, err := loadWASM(runtimeCtx)
 		if err != nil {
 			return nil, err
 		}
-		core = &ExtismCore{plugin: p}
+		return &ExtismCore{plugin: p}, nil
+	})
+}
+
+func getExtismCore(init func() (*ExtismCore, error)) (*CoreWrapper, error) {
+	return getExtismCoreWithLock(&coreMu, init)
+}
+
+// The injectable lock keeps lifecycle contention observable in deterministic unit tests.
+func getExtismCoreWithLock(coreLock sync.Locker, init func() (*ExtismCore, error)) (*CoreWrapper, error) {
+	coreLock.Lock()
+	defer coreLock.Unlock()
+
+	if core == nil {
+		initializedCore, err := init()
+		if err != nil {
+			return nil, err
+		}
+		core = initializedCore
 	}
 
 	coreWrapper := CoreWrapper{
@@ -44,6 +65,13 @@ func GetExtismCore() (*CoreWrapper, error) {
 }
 
 func ReleaseCore() {
+	releaseCoreWithLock(&coreMu)
+}
+
+func releaseCoreWithLock(coreLock sync.Locker) {
+	coreLock.Lock()
+	defer coreLock.Unlock()
+
 	core = nil
 }
 

--- a/internal/wasm_core_test.go
+++ b/internal/wasm_core_test.go
@@ -2,12 +2,38 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"sort"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type extismCoreResult struct {
+	wrapper *CoreWrapper
+	err     error
+}
+
+type observedCoreLock struct {
+	mutex   *sync.Mutex
+	blocked chan<- struct{}
+}
+
+func (l *observedCoreLock) Lock() {
+	if l.mutex.TryLock() {
+		return
+	}
+	l.blocked <- struct{}{}
+	l.mutex.Lock()
+}
+
+func (l *observedCoreLock) Unlock() {
+	l.mutex.Unlock()
+}
 
 func TestLoadWASM(t *testing.T) {
 	ctx := context.TODO()
@@ -35,4 +61,213 @@ func TestLoadWASM(t *testing.T) {
 	for x := range pluginHosts {
 		assert.Equal(t, pluginHosts[x], opHosts[x])
 	}
+}
+
+func TestGetExtismCoreConcurrentColdStartUsesOneCore(t *testing.T) {
+	ReleaseCore()
+	t.Cleanup(ReleaseCore)
+
+	initializerEntered := make(chan struct{})
+	finishInitialization := make(chan struct{})
+	var initializerCalls atomic.Int32
+	initializer := func() (*ExtismCore, error) {
+		initializedCore := &ExtismCore{}
+		if initializerCalls.Add(1) == 1 {
+			close(initializerEntered)
+			<-finishInitialization
+		}
+		return initializedCore, nil
+	}
+
+	lockBlocked := make(chan struct{}, 1)
+	observedLock := &observedCoreLock{
+		mutex:   &coreMu,
+		blocked: lockBlocked,
+	}
+	ready := make(chan struct{}, 2)
+	startFirst := make(chan struct{})
+	startSecond := make(chan struct{})
+	firstResult := make(chan extismCoreResult, 1)
+	secondResult := make(chan extismCoreResult, 1)
+	secondDone := make(chan struct{})
+
+	var callers sync.WaitGroup
+	callers.Add(2)
+	go func() {
+		defer callers.Done()
+		ready <- struct{}{}
+		<-startFirst
+		wrapper, err := getExtismCoreWithLock(observedLock, initializer)
+		firstResult <- extismCoreResult{wrapper: wrapper, err: err}
+	}()
+	go func() {
+		defer callers.Done()
+		defer close(secondDone)
+		ready <- struct{}{}
+		<-startSecond
+		wrapper, err := getExtismCoreWithLock(observedLock, initializer)
+		secondResult <- extismCoreResult{wrapper: wrapper, err: err}
+	}()
+
+	for range 2 {
+		<-ready
+	}
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+
+	close(startFirst)
+	select {
+	case <-initializerEntered:
+	case <-deadline.C:
+		close(startSecond)
+		close(finishInitialization)
+		t.Fatal("timed out waiting for the first initializer to start")
+	}
+
+	close(startSecond)
+	secondCompletedBeforeInitialization := false
+	select {
+	case <-lockBlocked:
+	case <-secondDone:
+		secondCompletedBeforeInitialization = true
+	case <-deadline.C:
+		close(finishInitialization)
+		t.Fatal("timed out waiting for the second caller to reach the lifecycle lock")
+	}
+	close(finishInitialization)
+
+	callersDone := make(chan struct{})
+	go func() {
+		callers.Wait()
+		close(callersDone)
+	}()
+	select {
+	case <-callersDone:
+	case <-deadline.C:
+		t.Fatal("timed out waiting for core callers to finish")
+	}
+
+	first := <-firstResult
+	second := <-secondResult
+	assert.False(t, secondCompletedBeforeInitialization, "second caller completed while the first initialization was blocked")
+	require.NoError(t, first.err)
+	require.NoError(t, second.err)
+	require.NotNil(t, first.wrapper)
+	require.NotNil(t, second.wrapper)
+	assert.Equal(t, int32(1), initializerCalls.Load())
+	assert.Same(t, first.wrapper.InnerCore, second.wrapper.InnerCore)
+}
+
+func TestGetExtismCoreRetriesAfterInitializationError(t *testing.T) {
+	ReleaseCore()
+	t.Cleanup(ReleaseCore)
+
+	initializationError := errors.New("initialization failed")
+	sentinelCore := &ExtismCore{}
+	var initializerCalls atomic.Int32
+	initializer := func() (*ExtismCore, error) {
+		if initializerCalls.Add(1) == 1 {
+			return nil, initializationError
+		}
+		return sentinelCore, nil
+	}
+
+	firstWrapper, firstErr := getExtismCore(initializer)
+	assert.Nil(t, firstWrapper)
+	assert.ErrorIs(t, firstErr, initializationError)
+
+	secondWrapper, secondErr := getExtismCore(initializer)
+	require.NoError(t, secondErr)
+	require.NotNil(t, secondWrapper)
+	assert.Same(t, sentinelCore, secondWrapper.InnerCore)
+
+	thirdWrapper, thirdErr := getExtismCore(initializer)
+	require.NoError(t, thirdErr)
+	require.NotNil(t, thirdWrapper)
+	assert.Same(t, sentinelCore, thirdWrapper.InnerCore)
+	assert.Equal(t, int32(2), initializerCalls.Load())
+}
+
+func TestReleaseCoreSynchronizesWithColdInitialization(t *testing.T) {
+	ReleaseCore()
+	t.Cleanup(ReleaseCore)
+
+	sentinelCore := &ExtismCore{}
+	initializerEntered := make(chan struct{})
+	finishInitialization := make(chan struct{})
+	initializerResult := make(chan extismCoreResult, 1)
+	releaseDone := make(chan struct{})
+	operationsDone := make(chan struct{})
+	lockBlocked := make(chan struct{}, 1)
+	observedLock := &observedCoreLock{
+		mutex:   &coreMu,
+		blocked: lockBlocked,
+	}
+
+	var operations sync.WaitGroup
+	operations.Add(1)
+	go func() {
+		defer operations.Done()
+		wrapper, err := getExtismCoreWithLock(observedLock, func() (*ExtismCore, error) {
+			close(initializerEntered)
+			<-finishInitialization
+			return sentinelCore, nil
+		})
+		initializerResult <- extismCoreResult{wrapper: wrapper, err: err}
+	}()
+
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+
+	select {
+	case <-initializerEntered:
+	case <-deadline.C:
+		close(finishInitialization)
+		t.Fatal("timed out waiting for initializer to start")
+	}
+
+	operations.Add(1)
+	go func() {
+		defer operations.Done()
+		defer close(releaseDone)
+		releaseCoreWithLock(observedLock)
+	}()
+
+	releaseCompletedDuringInitialization := false
+	select {
+	case <-lockBlocked:
+		select {
+		case <-releaseDone:
+			releaseCompletedDuringInitialization = true
+		default:
+		}
+	case <-releaseDone:
+		releaseCompletedDuringInitialization = true
+	case <-deadline.C:
+		close(finishInitialization)
+		t.Fatal("timed out waiting for release to reach the lifecycle lock")
+	}
+	close(finishInitialization)
+
+	go func() {
+		operations.Wait()
+		close(operationsDone)
+	}()
+
+	select {
+	case <-operationsDone:
+	case <-deadline.C:
+		t.Fatal("timed out waiting for initialization and release to finish")
+	}
+
+	result := <-initializerResult
+	assert.False(t, releaseCompletedDuringInitialization, "release completed while initialization held the lifecycle lock")
+	require.NoError(t, result.err)
+	require.NotNil(t, result.wrapper)
+	assert.Same(t, sentinelCore, result.wrapper.InnerCore)
+
+	coreMu.Lock()
+	finalCore := core
+	coreMu.Unlock()
+	assert.Nil(t, finalCore)
 }


### PR DESCRIPTION
## Summary

- serialize Extism core cold initialization, publication, wrapper capture, and registry reset with one lifecycle mutex
- prevent concurrent first callers from retaining duplicate Extism/Wazero runtimes
- preserve retry-after-load-failure behavior without caching errors or changing public APIs
- add bounded, credential-free regression coverage for concurrent cold starts, initialization retries, and release during initialization

## Problem

`GetExtismCore` previously read and published the package-global core without synchronization. Concurrent first callers could construct separate Extism/Wazero plugins and race while publishing them, while `ReleaseCore` could race with both initialization and warm reads.

The fix keeps `coreMu` held through cold loading and successful publication, and uses the same mutex for `ReleaseCore`. A failed load publishes nothing, so the next caller still retries.

The lifecycle tests use lightweight sentinel cores and an observable lock seam; they do not require credentials, network access, or construction of multiple real WASM runtimes.

## Local memory benchmark

A controlled 96-process benchmark compared base `5866f431` with this PR at `da768afd` on Darwin/arm64. Each measured sample ran in a fresh process using the same Go 1.27.1 toolchain, dependencies, WASM artifact, build flags, and `GOMAXPROCS=10`. Peak RSS came from `/usr/bin/time -l`; primary cold-start cells used five interleaved A/B repetitions.

| Simultaneous cold callers | Base median peak RSS | PR median peak RSS | Median paired reduction | Unique cores, base / PR |
|---:|---:|---:|---:|---:|
| 1 | 158.8 MiB | 159.4 MiB | none (+0.4%) | 1 / 1 |
| 2 | 289.5 MiB | 159.0 MiB | 44.9% | 2 / 1 |
| 3 | 418.4 MiB | 159.0 MiB | 62.0% | 3 / 1 |
| 4 | 547.3 MiB | 159.0 MiB | 71.0% | 4 / 1 |

All 15 concurrent-cold A/B pairs favored the PR. Every base run exposed 2, 3, or 4 distinct core identities at the corresponding concurrency, while every PR run exposed one. The lowest base peak still exceeded the highest PR peak by 127.6, 256.4, and 386.1 MiB at concurrency 2, 3, and 4.

Negative controls stayed flat: single-cold, sequential warm, concurrent warm, and release-only cases all remained near the one-core level (~159 MiB) in both builds. This indicates that the change removes duplicate simultaneous initialization; it does not reduce the normal one-core footprint or add deterministic plugin teardown.

Benchmark scope is direct, credential-free `internal.GetExtismCore` acquisition on Darwin/arm64 with up to four callers. It does not by itself establish Linux/container RSS, authenticated `NewClient` behavior, a permanent leak, or a specific production cgroup limit.

## Validation

- `git diff --check 5866f43111ffeee5952e43a13da1aafef98200c8`
- `gofmt -l internal/extism_core.go internal/wasm_core_test.go`
- `go build ./...`
- `go vet ./...`
- `go test ./internal/...`
- `go test -race ./internal/...`
- `go test -count=1 ./internal/...`
- `go test -race -count=1 ./internal/...`

## Scope

`Client.Close`, plugin destruction/reference counting, and broader runtime lifecycle redesign are intentionally out of scope.
